### PR TITLE
Make resets active low and asynchronous

### DIFF
--- a/proto/Peripherals.sv
+++ b/proto/Peripherals.sv
@@ -6,7 +6,7 @@ module Peripherals
 )
 (
     input  logic            clk,
-    input  logic            reset,
+    input  logic            reset_n,
     
     input  logic            enable_i,
     input  logic [3:0]      write_enable_i,
@@ -77,8 +77,8 @@ module Peripherals
 // BUTTON
 //////////////////////////////////////////////////////////////////////////////
 
-    always_ff @(posedge clk) begin
-        if (reset) begin
+    always_ff @(posedge clk or negedge reset_n) begin
+        if (!reset_n) begin
             button_irq <= 0;
         end
         else if (button_detected == 1'b1) begin
@@ -139,8 +139,8 @@ module Peripherals
         stall_r <= stall_o;
     end
 
-    always_ff @(posedge clk) begin
-        if(reset)begin
+    always_ff @(posedge clk or negedge reset_n) begin
+        if(!reset_n)begin
             data_o <= '0;
         end
         else begin
@@ -170,8 +170,8 @@ module Peripherals
     // UART RX
     //////////////////////////////////////////////////////////////////////////////
 
-    always_ff @(posedge clk) begin
-        if (reset) begin
+    always_ff @(posedge clk or negedge reset_n) begin
+        if (!reset_n) begin
             UART_RX_irq <= 0;
         end
         else if (UART_RX_ready == 1'b1) begin
@@ -181,8 +181,8 @@ module Peripherals
             UART_RX_irq <= 0;
         end
     end
-    always_ff @(posedge clk) begin
-        if (reset) begin
+    always_ff @(posedge clk or negedge reset_n) begin
+        if (!reset_n) begin
             UART_RX_data_reg <= '0;
         end 
         else begin
@@ -205,7 +205,7 @@ module Peripherals
 
     FIFO_BUFFER_UART FIFO_BUFFER_UART1 (
         .clk    (clk),                  // input wire clk
-        .srst   (reset),                // input wire srst
+        .srst   (!reset_n),                // input wire srst
         .din    (BUFFER_data),          // input wire [7 : 0] din
         .wr_en  (BUFFER_write),         // input wire wr_en
         .rd_en  (BUFFER_read),          // input wire rd_en

--- a/proto/RS5/RS5.srcs/constrs_1/new/constraint.xdc
+++ b/proto/RS5/RS5.srcs/constrs_1/new/constraint.xdc
@@ -71,7 +71,7 @@ create_clock -add -name sys_clk_pin -period 10.00 -waveform {0 5} [get_ports {cl
 #set_property -dict { PACKAGE_PIN U13   IOSTANDARD LVCMOS33 } [get_ports { an[7] }]; #IO_L23N_T3_A02_D18_14 Sch=an[7]
 
 ##Buttons
-set_property -dict { PACKAGE_PIN C12   IOSTANDARD LVCMOS33 } [get_ports { reset }]; #IO_L3P_T0_DQS_AD1P_15 Sch=cpu_resetn
+set_property -dict { PACKAGE_PIN C12   IOSTANDARD LVCMOS33 } [get_ports { reset_n }]; #IO_L3P_T0_DQS_AD1P_15 Sch=cpu_resetn
 #set_property -dict { PACKAGE_PIN N17   IOSTANDARD LVCMOS33 } [get_ports { BTNC }]; #IO_L9P_T1_DQS_14 Sch=btnc
 #set_property -dict { PACKAGE_PIN M18   IOSTANDARD LVCMOS33 } [get_ports { reset }]; #IO_L4N_T0_D05_14 Sch=btnu
 #set_property -dict { PACKAGE_PIN P17   IOSTANDARD LVCMOS33 } [get_ports { BTNL }]; #IO_L12P_T1_MRCC_14 Sch=btnl

--- a/proto/RS5_FPGA_Platform.sv
+++ b/proto/RS5_FPGA_Platform.sv
@@ -10,7 +10,7 @@ module RS5_FPGA_Platform
 )
 (
     input  logic       clk,
-    input  logic       reset,
+    input  logic       reset_n,
     input  logic       BTND,
     input  logic       UART_RX,
     output logic       UART_TX
@@ -102,7 +102,7 @@ module RS5_FPGA_Platform
         .ZIHPMEnable    (ZIHPMEnable)
     ) dut (
         .clk                    (clk), 
-        .reset                  (!reset),
+        .reset_n                (reset_n),
         .stall                  (stall),
         .instruction_i          (cpu_instruction), 
         .mem_data_i             (cpu_data_in), 
@@ -142,7 +142,7 @@ module RS5_FPGA_Platform
 
     rtc rtc(
         .clk        (clk),
-        .reset      (!reset),
+        .reset_n    (reset_n),
         .en_i       (enable_rtc),
         .addr_i     (cpu_data_address[3:0]),
         .we_i       ({4'h0, cpu_write_enable}),
@@ -159,17 +159,17 @@ module RS5_FPGA_Platform
     plic #(
         .i_cnt(i_cnt)
     ) plic1 (
-        .clk    (clk),
-        .reset  (!reset),
-        .en_i   (enable_plic),
-        .we_i   (cpu_write_enable),
-        .addr_i (cpu_data_address[23:0]),
-        .data_i (cpu_data_out),
-        .data_o (data_plic),     
-        .irq_i  (irq_peripherals),
-        .iack_i (interrupt_ack),
-        .irq_o  (mei),
-        .iack_o (iack_peripherals)
+        .clk     (clk),
+        .reset_n (reset_n),
+        .en_i    (enable_plic),
+        .we_i    (cpu_write_enable),
+        .addr_i  (cpu_data_address[23:0]),
+        .data_i  (cpu_data_out),
+        .data_o  (data_plic),     
+        .irq_i   (irq_peripherals),
+        .iack_i  (interrupt_ack),
+        .irq_o   (mei),
+        .iack_o  (iack_peripherals)
     );
 
 //////////////////////////////////////////////////////////////////////////////
@@ -181,7 +181,7 @@ module RS5_FPGA_Platform
         .CLKS_PER_BIT_UART(CLKS_PER_BIT_UART)
     ) Peripherals1 (
         .clk            (clk), 
-        .reset          (!reset), 
+        .reset_n        (reset_n), 
         .stall_o        (stall),
         .enable_i       (enable_peripherals), 
         .write_enable_i (cpu_write_enable),

--- a/proto/Testbench_FPGA_Platform.sv
+++ b/proto/Testbench_FPGA_Platform.sv
@@ -64,7 +64,7 @@ module Testbench_FPGA_Platform ();
         .CLKS_PER_BIT_UART(5)
     ) dut (
         .clk        (clk), 
-        .reset      (rstCPU), 
+        .reset_n    (rstCPU), 
         .BTND       (BTND),
         .UART_RX    (UART_RX)
     );

--- a/rtl/CSRBank.sv
+++ b/rtl/CSRBank.sv
@@ -34,7 +34,7 @@ module CSRBank
 )
 (
     input   logic               clk,
-    input   logic               reset,
+    input   logic               reset_n,
 
     input   logic               read_enable_i,
     input   logic               write_enable_i,
@@ -241,11 +241,11 @@ module CSRBank
 // CSR Writing
 //////////////////////////////////////////////////////////////////////////////
 
-    always_ff @(posedge clk) begin
+    always_ff @(posedge clk or negedge reset_n) begin
         //////////////////////////////////////////////////////////////////////////////
         // Reset
         //////////////////////////////////////////////////////////////////////////////
-        if (reset == 1'b1) begin
+        if (!reset_n) begin
             mstatus_mie      <= 1'b0;
             mstatus_mprv     <= 1'b0;
             misa             <= MISA_VALUE;
@@ -439,8 +439,8 @@ module CSRBank
 //////////////////////////////////////////////////////////////////////////////
     
     if (XOSVMEnable == 1'b1) begin : gen_xosvm_csr_on
-        always_ff @(posedge clk) begin
-            if (reset == 1'b1) begin
+        always_ff @(posedge clk or negedge reset_n) begin
+            if (!reset_n) begin
                 mvmctl      <= '0;
                 mvmdo       <= '0;
                 mvmds       <= '0;
@@ -495,8 +495,8 @@ module CSRBank
             MTIE = mie[ 7],
             MSIE = mie[ 3];
 
-    always_ff @(posedge clk) begin
-        if (reset == 1'b1) begin
+    always_ff @(posedge clk or negedge reset_n) begin
+        if (!reset_n) begin
             mip <= '0;
         end
         else begin
@@ -527,8 +527,8 @@ module CSRBank
     if (ZIHPMEnable == 1'b1) begin : gen_zihpm_csr_on
         int fd;
 
-        always_ff @(posedge clk) begin
-            if (reset == 1'b1) begin
+        always_ff @(posedge clk or negedge reset_n) begin
+            if (!reset_n) begin
                 instructions_killed_counter <= '0;
                 nop_counter                 <= '0;
                 logic_counter               <= '0;

--- a/rtl/RS5.sv
+++ b/rtl/RS5.sv
@@ -30,7 +30,7 @@ module RS5
 )
 (
     input  logic                    clk,
-    input  logic                    reset,
+    input  logic                    reset_n,
     input  logic                    stall,
 
     input  logic [31:0]             instruction_i,
@@ -166,7 +166,7 @@ module RS5
 
     fetch fetch1 (
         .clk                    (clk), 
-        .reset                  (reset), 
+        .reset_n                (reset_n), 
         .enable                 (enable_fetch),
         .jump_i                 (jump), 
         .jump_target_i          (jump_target),
@@ -203,7 +203,7 @@ module RS5
 
     decode decoder1 (
         .clk                        (clk), 
-        .reset                      (reset),
+        .reset_n                    (reset_n),
         .enable                     (enable_decode),
         .instruction_i              (instruction_i), 
         .pc_i                       (pc_decode), 
@@ -253,7 +253,7 @@ module RS5
     else begin : RegFileFF_blk
         regbank regbankff (
             .clk        (clk),
-            .reset      (reset),
+            .reset_n    (reset_n),
             .rs1        (rs1), 
             .rs2        (rs2),
             .rd         (rd), 
@@ -272,7 +272,7 @@ module RS5
         .RV32        (RV32)
     ) execute1 (
         .clk                    (clk), 
-        .reset                  (reset), 
+        .reset_n                (reset_n), 
         .stall                  (stall),
         .instruction_i          (instruction_execute), 
         .pc_i                   (pc_execute), 
@@ -329,7 +329,7 @@ module RS5
       .RV32         (RV32       )
     ) CSRBank1 (
         .clk                        (clk), 
-        .reset                      (reset), 
+        .reset_n                    (reset_n), 
         .read_enable_i              (csr_read_enable), 
         .write_enable_i             (csr_write_enable), 
         .operation_i                (csr_operation), 

--- a/rtl/decode.sv
+++ b/rtl/decode.sv
@@ -27,7 +27,7 @@ module decode
     import RS5_pkg::*;
 (
     input   logic           clk,
-    input   logic           reset,
+    input   logic           reset_n,
     input   logic           enable,
 
     input   logic [31:0]    instruction_i,
@@ -263,8 +263,8 @@ module decode
 // Registe Lock Queue (RLQ)
 //////////////////////////////////////////////////////////////////////////////
 
-    always_ff @(posedge clk) begin
-        if (reset == 1'b1) begin
+    always_ff @(posedge clk or negedge reset_n) begin
+        if (!reset_n) begin
             locked_register <= '0;
             locked_memory   <= '0;
         end 
@@ -381,8 +381,8 @@ module decode
 // Outputs
 //////////////////////////////////////////////////////////////////////////////
 
-    always_ff @(posedge clk) begin
-        if (reset == 1'b1) begin
+    always_ff @(posedge clk or negedge reset_n) begin
+        if (!reset_n) begin
             first_operand_o         <= '0;
             second_operand_o        <= '0;
             third_operand_o         <= '0;

--- a/rtl/decode.sv
+++ b/rtl/decode.sv
@@ -69,10 +69,17 @@ module decode
 // Re-Decode isntruction on hazard or stall
 //////////////////////////////////////////////////////////////////////////////
 
+    always_ff @(posedge clk or negedge reset_n) begin
+        if (!reset_n) begin
+            last_instruction <= 32'h00000013;
+        end else begin
+            last_instruction <= instruction;
+        end
+    end
+
     always_ff @(posedge clk) begin
-        last_instruction <= instruction;
-        last_hazard      <= hazard_o;
-        last_stall       <= ~enable;
+        last_hazard <= hazard_o;
+        last_stall  <= ~enable;
     end
 
     always_comb begin

--- a/rtl/div.sv
+++ b/rtl/div.sv
@@ -4,7 +4,7 @@ module div
     import RS5_pkg::*;
 (
     input   logic        clk,
-    input   logic        reset,
+    input   logic        reset_n,
 
     input   logic [31:0] first_operand_i,
     input   logic [31:0] second_operand_i,
@@ -90,10 +90,10 @@ module div
         end
     end
 
-    always_ff @(posedge clk) begin
+    always_ff @(posedge clk or negedge reset_n) begin
         logic [4:0] i;
 
-        if (reset == 1'b1) begin
+        if (!reset_n) begin
             busy_unsig_div    <= 1'b0;
             valid_unsig_div   <= 1'b0;
             acc_unsig_div     <= '0;
@@ -145,10 +145,10 @@ module div
         end
     end
 
-    always_ff @(posedge clk) begin
+    always_ff @(posedge clk or negedge reset_n) begin
         logic [4:0] i;
 
-        if (reset == 1'b1) begin
+        if (!reset_n) begin
             div_state       <= D_IDLE; 
             busy_sig_div    <= 1'b0;
             valid_sig_div   <= 1'b0;

--- a/rtl/execute.sv
+++ b/rtl/execute.sv
@@ -34,7 +34,7 @@ module execute
 )
 (
     input   logic               clk,
-    input   logic               reset,
+    input   logic               reset_n,
     input   logic               stall,
 
     /* Bits 14:12 and 6:0 are not used in this module */
@@ -257,7 +257,7 @@ end
     if (RV32 == RV32M || RV32 == RV32ZMMUL) begin : gen_zmmul_on
         mul mul1 (
             .clk                        (clk),
-            .reset                      (reset),
+            .reset_n                    (reset_n),
             .first_operand_i            (first_operand_i),
             .second_operand_i           (second_operand_i),
             .instruction_operation_i    (instruction_operation_i),
@@ -281,7 +281,7 @@ end
     if (RV32 == RV32M) begin : gen_div_on
         div div1 (
             .clk                        (clk),
-            .reset                      (reset),
+            .reset_n                    (reset_n),
             .first_operand_i            (first_operand_i),
             .second_operand_i           (second_operand_i),
             .instruction_operation_i    (instruction_operation_i),
@@ -390,8 +390,8 @@ end
 // TAG control based on signals Jump and Killed
 //////////////////////////////////////////////////////////////////////////////
 
-    always_ff @(posedge clk) begin
-        if (reset == 1'b1) begin
+    always_ff @(posedge clk or negedge reset_n) begin
+        if (!reset_n) begin
             curr_tag <= 0;
         end
         else if ((jump_o | raise_exception_o | machine_return_o | interrupt_ack_o) == 1'b1) begin
@@ -404,7 +404,7 @@ end
 //////////////////////////////////////////////////////////////////////////////
 
     always_comb begin
-        if ((reset | killed) == 1'b0) begin
+        if ((!reset_n | killed) == 1'b0) begin
             if (exc_inst_access_fault_i == 1'b1) begin
                 raise_exception_o = 1'b1;
                 machine_return_o  = 1'b0;

--- a/rtl/execute.sv
+++ b/rtl/execute.sv
@@ -341,10 +341,13 @@ end
 // Output Registers
 //////////////////////////////////////////////////////////////////////////////
 
-    always_ff @(posedge clk) begin
-        if (
-            stall == 1'b0 & hold_o == 1'b0
-        ) begin
+    always_ff @(posedge clk or negedge reset_n) begin
+        if (!reset_n) begin
+            write_enable_o          <= 1'b0;
+            instruction_operation_o <= NOP;
+            result_o                <= '0;       
+        end
+        else if (stall == 1'b0 & hold_o == 1'b0) begin
             write_enable_o          <= write_enable;
             instruction_operation_o <= instruction_operation_i;
             result_o                <= result;             

--- a/rtl/fetch.sv
+++ b/rtl/fetch.sv
@@ -23,7 +23,7 @@
 
 module fetch  #(parameter start_address = 32'b0)(
     input   logic           clk,
-    input   logic           reset,
+    input   logic           reset_n,
     input   logic           enable,
 
     input   logic           jump_i,
@@ -47,8 +47,8 @@ module fetch  #(parameter start_address = 32'b0)(
 // PC Control
 //////////////////////////////////////////////////////////////////////////////
 
-    always_ff @(posedge clk) begin
-        if (reset == 1'b1) begin
+    always_ff @(posedge clk or negedge reset_n) begin
+        if (!reset_n) begin
             pc <= start_address;
         end
         else if (machine_return_i == 1'b1) begin                              
@@ -86,8 +86,8 @@ module fetch  #(parameter start_address = 32'b0)(
 // TAG Calculator 
 //////////////////////////////////////////////////////////////////////////////
 
-    always_ff @(posedge clk) begin
-        if (reset == 1'b1) begin
+    always_ff @(posedge clk or negedge reset_n) begin
+        if (!reset_n) begin
             current_tag <= '0;
             next_tag    <= '0;
         end

--- a/rtl/fetch.sv
+++ b/rtl/fetch.sv
@@ -69,8 +69,11 @@ module fetch  #(parameter start_address = 32'b0)(
 // Sensitive Outputs 
 //////////////////////////////////////////////////////////////////////////////
     
-    always_ff @(posedge clk) begin
-        if (enable == 1'b1) begin
+    always_ff @(posedge clk or negedge reset_n) begin
+        if (!reset_n) begin
+            pc_o <= '0;
+        end
+        else if (enable == 1'b1) begin
             pc_o <= pc;
         end
     end

--- a/rtl/mul.sv
+++ b/rtl/mul.sv
@@ -9,7 +9,7 @@ module mul
     import RS5_pkg::*;
 (
     input   logic        clk,
-    input   logic        reset,
+    input   logic        reset_n,
 
     input   logic [31:0] first_operand_i,
     input   logic [31:0] second_operand_i,
@@ -51,8 +51,8 @@ module mul
     
     assign mac_result   = $signed({sign_a, op_a}) * $signed({sign_b, op_b}) + $signed(accum);     
 
-    always_ff @(posedge clk) begin
-        if (reset) begin
+    always_ff @(posedge clk or negedge reset_n) begin
+        if (!reset_n) begin
             mac_result_reg <= 0;
         end 
         else begin
@@ -144,8 +144,8 @@ module mul
         endcase
     end
 
-    always_ff@(posedge clk) begin
-        if (reset) begin
+    always_ff@(posedge clk or negedge reset_n) begin
+        if (!reset_n) begin
             mul_state <= ALBL;
         end else begin
             mul_state <= next_state;

--- a/rtl/plic.sv
+++ b/rtl/plic.sv
@@ -7,7 +7,7 @@ module plic
 )
 (
     input   logic                   clk,
-    input   logic                   reset,
+    input   logic                   reset_n,
 
     input   logic                   en_i,
     input   logic  [3:0]            we_i,
@@ -33,8 +33,8 @@ module plic
     logic [i_cnt:1] ip;
     logic [i_cnt:1] interrupt;
 
-    always_ff @(posedge clk) begin
-        if (reset == 1'b1) begin
+    always_ff @(posedge clk or negedge reset_n) begin
+        if (!reset_n) begin
             ip <= '0;
         end
         else begin
@@ -54,15 +54,15 @@ module plic
 		end
 	end
 
-    always_ff @(posedge clk) begin
-        if (reset == 1'b1)
+    always_ff @(posedge clk or negedge reset_n) begin
+        if (!reset_n)
             id_r <= '0;
         else
             id_r <= id_int;
     end
 
-    always_ff @(posedge clk) begin
-        if (reset == 1'b1) begin
+    always_ff @(posedge clk or negedge reset_n) begin
+        if (!reset_n) begin
             iack_o <= '0;
         end
         else begin
@@ -78,8 +78,8 @@ module plic
 // Memory Mapped Regs
 /////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 
-    always_ff @( posedge clk ) begin
-        if (reset == 1'b1) begin
+    always_ff @(posedge clk or negedge reset_n) begin
+        if (!reset_n) begin
             ie      <= '0;
             data_o  <= '0;
         end  

--- a/rtl/regbank.sv
+++ b/rtl/regbank.sv
@@ -25,7 +25,7 @@ module regbank
     import RS5_pkg::*;
 (
     input   logic         clk, 
-    input   logic         reset,
+    input   logic         reset_n,
 
     input   logic [4:0]   rs1,
     input   logic [4:0]   rs2,
@@ -56,8 +56,8 @@ module regbank
 //////////////////////////////////////////////////////////////////////////////
 
     for (genvar i = 1; i < 32 ; i++) begin : gen_regfile
-        always_ff @(posedge clk) begin
-            if (reset == 1'b1) begin
+        always_ff @(posedge clk or negedge reset_n) begin
+            if (!reset_n) begin
                 regfile[i] <= '0;
             end
             else if (rd == i && enable == 1'b1) begin

--- a/rtl/rtc.sv
+++ b/rtl/rtc.sv
@@ -17,7 +17,7 @@
 
 module rtc (
     input  logic        clk,
-    input  logic        reset,
+    input  logic        reset_n,
     input  logic        en_i,
     input  logic [3:0]  addr_i,
     input  logic [7:0]  we_i,
@@ -34,8 +34,8 @@ module rtc (
     assign intr = (memory[7:0] >= memory[15:8]);
     assign mtime_o = memory[7:0];
 
-    always_ff @(posedge clk) begin
-        if (reset == 1'b1) begin
+    always_ff @(posedge clk or negedge reset_n) begin
+        if (!reset_n) begin
             mti_o <= 1'b0;
         end
         else begin
@@ -43,9 +43,9 @@ module rtc (
         end
     end
 
-    always_ff @(posedge clk) begin
+    always_ff @(posedge clk or negedge reset_n) begin
         memory[7:0] <= memory[7:0] + 1'b1;
-        if (reset == 1'b1) begin
+        if (!reset_n) begin
             memory <= '0;
             data_o <= '0;
         end

--- a/sim/tb_top.sv
+++ b/sim/tb_top.sv
@@ -6,7 +6,7 @@ module tb_top
     import RS5_pkg::*;
 ;
 
-    logic        clk=1, rstCPU;
+    logic        clk=1, reset_n;
     
     testbench #(
         .INSTRUCTION_SET(RV32M),
@@ -14,7 +14,7 @@ module tb_top
         .USE_ZIHPM(1'b1)
     ) tb (
         .clk_i(clk),
-        .rst_n_i(rstCPU)
+        .reset_n(reset_n)
     );
 
 ///////////////////////////////////////// Clock generator //////////////////////////////
@@ -27,9 +27,9 @@ module tb_top
 ////////////////////////////////////////////////////// RESET CPU ////////////////////////////////////////////////////////////////////////////////////
 /////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
     initial begin
-        rstCPU = 0;                                          // RESET for CPU initialization
+        reset_n = 0;                                          // RESET for CPU initialization
         
-        #100 rstCPU = 1;                                     // Hold state for 100 ns
+        #100 reset_n = 1;                                     // Hold state for 100 ns
     end
 
 endmodule

--- a/sim/tb_top.sv
+++ b/sim/tb_top.sv
@@ -14,7 +14,7 @@ module tb_top
         .USE_ZIHPM(1'b1)
     ) tb (
         .clk_i(clk),
-        .rst_i(rstCPU)
+        .rst_n_i(rstCPU)
     );
 
 ///////////////////////////////////////// Clock generator //////////////////////////////
@@ -27,9 +27,9 @@ module tb_top
 ////////////////////////////////////////////////////// RESET CPU ////////////////////////////////////////////////////////////////////////////////////
 /////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
     initial begin
-        rstCPU = 1;                                          // RESET for CPU initialization
+        rstCPU = 0;                                          // RESET for CPU initialization
         
-        #100 rstCPU = 0;                                     // Hold state for 100 ns
+        #100 rstCPU = 1;                                     // Hold state for 100 ns
     end
 
 endmodule

--- a/sim/testbench.sv
+++ b/sim/testbench.sv
@@ -30,7 +30,7 @@ module testbench
 )
 (
     input logic clk_i,
-    input logic rst_i
+    input logic rst_n_i
 );
 
 //////////////////////////////////////////////////////////////////////////////
@@ -142,7 +142,7 @@ module testbench
         .ZIHPMEnable(USE_ZIHPM)
     ) dut (
         .clk                    (clk_i), 
-        .reset                  (rst_i), 
+        .reset_n                (rst_n_i), 
         .stall                  (1'b0),
         .instruction_i          (instruction), 
         .mem_data_i             (mem_data_read), 
@@ -191,17 +191,17 @@ module testbench
     plic #(
         .i_cnt(i_cnt)
     ) plic1 (
-        .clk    (clk_i),
-        .reset  (rst_i),
-        .en_i   (enable_plic),
-        .we_i   (mem_write_enable),
-        .addr_i (mem_address[23:0]),
-        .data_i (mem_data_write),
-        .data_o (data_plic),     
-        .irq_i  ('0),
-        .iack_i (interrupt_ack),
-        .iack_o (iack_periph),
-        .irq_o  (mei)
+        .clk     (clk_i),
+        .reset_n (rst_n_i),
+        .en_i    (enable_plic),
+        .we_i    (mem_write_enable),
+        .addr_i  (mem_address[23:0]),
+        .data_i  (mem_data_write),
+        .data_o  (data_plic),     
+        .irq_i   ('0),
+        .iack_i  (interrupt_ack),
+        .iack_o  (iack_periph),
+        .irq_o   (mei)
     );
 
 //////////////////////////////////////////////////////////////////////////////
@@ -210,7 +210,7 @@ module testbench
 
     rtc rtc(
         .clk        (clk_i),
-        .reset      (rst_i), 
+        .reset_n    (rst_n_i), 
         .en_i       (enable_rtc),
         .addr_i     (mem_address[3:0]),
         .we_i       ({4'h0, mem_write_enable}),

--- a/sim/testbench.sv
+++ b/sim/testbench.sv
@@ -30,7 +30,7 @@ module testbench
 )
 (
     input logic clk_i,
-    input logic rst_n_i
+    input logic reset_n
 );
 
 //////////////////////////////////////////////////////////////////////////////
@@ -142,7 +142,7 @@ module testbench
         .ZIHPMEnable(USE_ZIHPM)
     ) dut (
         .clk                    (clk_i), 
-        .reset_n                (rst_n_i), 
+        .reset_n                (reset_n), 
         .stall                  (1'b0),
         .instruction_i          (instruction), 
         .mem_data_i             (mem_data_read), 
@@ -192,7 +192,7 @@ module testbench
         .i_cnt(i_cnt)
     ) plic1 (
         .clk     (clk_i),
-        .reset_n (rst_n_i),
+        .reset_n (reset_n),
         .en_i    (enable_plic),
         .we_i    (mem_write_enable),
         .addr_i  (mem_address[23:0]),
@@ -210,7 +210,7 @@ module testbench
 
     rtc rtc(
         .clk        (clk_i),
-        .reset_n    (rst_n_i), 
+        .reset_n    (reset_n), 
         .en_i       (enable_rtc),
         .addr_i     (mem_address[3:0]),
         .we_i       ({4'h0, mem_write_enable}),


### PR DESCRIPTION
This PR includes changes to the reset signal and a fix related to uninitialized internal signals.

- Changes all resets to active low and asynchronous
- Changes the reset signal name to reset_n 
- Initializes internal signals related to instruction fetching and decoding to known values, to prevent possible errors