### PR TITLE
Fix incorrect writes to regbank

### DIFF
--- a/rtl/execute.sv
+++ b/rtl/execute.sv
@@ -497,6 +497,11 @@ end
             instruction_operation_o <= instruction_operation_i;
             result_o                <= result;
         end
+        else begin
+            write_enable_o          <= 1'b0;
+            instruction_operation_o <= NOP;
+            result_o                <= '0;
+        end
     end
 
 //////////////////////////////////////////////////////////////////////////////


### PR DESCRIPTION
This PR fixes a possible edge case where a LW instruction followed by a multi-cycle instruciton would result in multiple incorrect writes to the regbank due to the write_enable signal staying active during the hold.