### PR TITLE
Flush align with sys_reset

### DIFF
--- a/rtl/RS5.sv
+++ b/rtl/RS5.sv
@@ -261,6 +261,7 @@ module RS5
         align align (
             .clk                (clk),
             .reset_n            (reset_n),
+            .sys_reset          (sys_reset_i),
             .enable_i           (enable_prefetch),
             .hazard_i           (hazard),
             .jumped_i           (jumped),

--- a/rtl/align.sv
+++ b/rtl/align.sv
@@ -14,6 +14,7 @@ module align
 (
     input  logic        clk,
     input  logic        reset_n,
+    input  logic        sys_reset,
 
     input  logic        enable_i,
     input  logic        hazard_i,
@@ -55,7 +56,7 @@ module align
         end
     end
 
-    assign flush_align = jump_i || jump_r;
+    assign flush_align = jump_i || jump_r || sys_reset;
 
 //////////////////////////////////////////////////////////////////////////////
 // Compression control


### PR DESCRIPTION
This PR fixes an issue that could make the PC not reset properly when doing a sys_reset. The align stage is now flushed to prevent this issue.