### PR TITLE
Add forwarding from execute to decoder

### DIFF
--- a/proto/RS5/RS5.xpr
+++ b/proto/RS5/RS5.xpr
@@ -4,7 +4,7 @@
 <!-- Copyright 1986-2022 Xilinx, Inc. All Rights Reserved.                   -->
 <!-- Copyright 2022-2023 Advanced Micro Devices, Inc. All Rights Reserved.   -->
 
-<Project Product="Vivado" Version="7" Minor="65" Path="/sim/lucas.luza/wimed/soc/RS5/proto/RS5/RS5.xpr">
+<Project Product="Vivado" Version="7" Minor="65" Path="/sim/angelo.dalzotto/RS5/proto/RS5/RS5.xpr">
   <DefaultLaunch Dir="$PRUNDIR"/>
   <Configuration>
     <Option Name="Id" Val="29f547082ef44dd2aa383b58a59302c8"/>
@@ -402,7 +402,6 @@
         <FileInfo>
           <Attr Name="UsedIn" Val="synthesis"/>
           <Attr Name="UsedIn" Val="implementation"/>
-          <Attr Name="UsedInSteps" Val="impl_1"/>
           <Attr Name="AutoDcp" Val="1"/>
         </FileInfo>
       </File>
@@ -439,6 +438,7 @@
           <Desc>Vivado Synthesis Defaults</Desc>
         </StratHandle>
         <Step Id="synth_design">
+          <Option Id="FsmExtraction">1</Option>
           <Option Id="GlobalReTiming">1</Option>
           <Option Id="ReTiming">1</Option>
         </Step>
@@ -448,7 +448,7 @@
       <Report Name="ROUTE_DESIGN.REPORT_METHODOLOGY" Enabled="1"/>
       <RQSFiles/>
     </Run>
-    <Run Id="impl_1" Type="Ft2:EntireDesign" Part="xc7a100tcsg324-1" ConstrsSet="constrs_1" Description="Similar to Performance_ExplorePostRoutePhysOpt, but enables logic optimization step (opt_design) with the ExploreWithRemap directive." AutoIncrementalCheckpoint="true" IncrementalCheckpoint="$PSRCDIR/utils_1/imports/impl_1/RS5_FPGA_Platform_routed.dcp" WriteIncrSynthDcp="false" State="current" Dir="$PRUNDIR/impl_1" SynthRun="synth_1" IncludeInArchive="true" IsChild="false" GenFullBitstream="true" AutoIncrementalDir="$PSRCDIR/utils_1/imports/impl_1" LaunchOptions="-jobs 32 " AutoRQSDir="$PSRCDIR/utils_1/imports/impl_1">
+    <Run Id="impl_1" Type="Ft2:EntireDesign" Part="xc7a100tcsg324-1" ConstrsSet="constrs_1" Description="Similar to Performance_ExplorePostRoutePhysOpt, but enables logic optimization step (opt_design) with the ExploreWithRemap directive." AutoIncrementalCheckpoint="false" WriteIncrSynthDcp="false" State="current" Dir="$PRUNDIR/impl_1" SynthRun="synth_1" IncludeInArchive="true" IsChild="false" GenFullBitstream="true" AutoIncrementalDir="$PSRCDIR/utils_1/imports/impl_1" LaunchOptions="-jobs 24 " AutoRQSDir="$PSRCDIR/utils_1/imports/impl_1">
       <Strategy Version="1" Minor="2">
         <StratHandle Name="Performance_ExploreWithRemap" Flow="Vivado Implementation 2023">
           <Desc>Similar to Performance_ExplorePostRoutePhysOpt, but enables logic optimization step (opt_design) with the ExploreWithRemap directive.</Desc>

--- a/rtl/RS5.sv
+++ b/rtl/RS5.sv
@@ -170,6 +170,7 @@ module RS5
     logic        ctx_switch;
     logic        bp_take_fetch;
     logic        bp_rollback;
+    logic        compressed_decode;
     logic [31:0] bp_target;
     logic [31:0] ctx_switch_target;
     logic [31:0] instruction_decode;
@@ -190,6 +191,7 @@ module RS5
         .jumping_o              (jumping),
         .bp_rollback_o          (bp_rollback),
         .jump_misaligned_o      (jump_misaligned),
+        .compressed_o           (compressed_decode),
         .instruction_address_o  (instruction_address), 
         .instruction_data_i     (instruction_i),
         .instruction_o          (instruction_decode),
@@ -258,6 +260,7 @@ module RS5
         .jumping_i                  (jumping),
         .jump_rollback_i            (jump_rollback),
         .rollback_i                 (bp_rollback),
+        .compressed_i               (compressed_decode),
         .jump_misaligned_i          (jump_misaligned),
         .bp_take_o                  (bp_take_fetch),
         .bp_taken_o                 (bp_taken_exec),

--- a/rtl/RS5.sv
+++ b/rtl/RS5.sv
@@ -216,7 +216,9 @@ module RS5
 /////////////////////////////////////////////////////////// DECODER /////////////////////////////////////////////////////////////////////////////////
 /////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 
-    logic bp_taken_exec;
+    logic        bp_taken_exec;
+    logic        write_enable_exec;
+    logic [31:0] result_exec;
 
     decode # (
         .MULEXT    (MULEXT    ),
@@ -234,7 +236,9 @@ module RS5
         .rs2_data_read_i            (regbank_data2),
         .rd_retire_i                (rd_retire),
         .writeback_i                (regbank_data_writeback),
+        .result_i                   (result_exec),
         .regbank_we_i               (regbank_write_enable),
+        .execute_we_i               (write_enable_exec),
         .rs1_o                      (rs1),
         .rs2_o                      (rs2),
         .rd_o                       (rd_execute),
@@ -338,8 +342,10 @@ module RS5
         .exc_load_access_fault_i (mmu_data_fault),
         .hold_o                  (hold),
         .write_enable_o          (regbank_write_enable),
+        .write_enable_fwd_o      (write_enable_exec),
         .instruction_operation_o (instruction_operation_retire),
         .result_o                (result_retire),
+        .result_fwd_o            (result_exec),
         .rd_o                    (rd_retire),
         .mem_address_o           (mem_address),
         .mem_read_enable_o       (mem_read_enable),

--- a/rtl/decode.sv
+++ b/rtl/decode.sv
@@ -455,7 +455,7 @@ module decode
     logic hazard_rs1;
     logic hazard_rs2;
 
-    assign use_mem = ({opcode[6], opcode[4:2]} == '0);
+    assign use_mem = (opcode[6:2] == '0); // LOAD
 
     always_comb begin
         unique case (instruction_format)

--- a/rtl/execute.sv
+++ b/rtl/execute.sv
@@ -319,13 +319,14 @@ end
         mul mul1 (
             .clk              (clk),
             .reset_n          (reset_n),
+            .stall            (stall),
             .first_operand_i  (first_operand_i),
             .second_operand_i (second_operand_i),
             .signed_mode_i    (signed_mode_mul),
             .enable_i         (enable_mul),
             .mul_low_i        (mul_low),
-            .single_cycle_i   (1'b0),
             .hold_o           (hold_mul),
+            .single_cycle_i   (1'b0),
             .result_o         (mul_result)
         );
     end

--- a/rtl/execute.sv
+++ b/rtl/execute.sv
@@ -63,9 +63,11 @@ module execute
 
     output  logic               hold_o,
     output  logic               write_enable_o,
+    output  logic               write_enable_fwd_o,
     output  iType_e             instruction_operation_o,
-    output  logic [31:0]        result_o,
-    output  logic  [4:0]        rd_o,
+    output  logic   [31:0]      result_o,
+    output  logic   [31:0]      result_fwd_o,
+    output  logic   [ 4:0]      rd_o,
 
     output  logic [31:0]        mem_address_o,
     output  logic               mem_read_enable_o,
@@ -477,6 +479,8 @@ end
         endcase
     end
 
+    assign write_enable_fwd_o = write_enable;
+
 //////////////////////////////////////////////////////////////////////////////
 // Output Registers
 //////////////////////////////////////////////////////////////////////////////
@@ -502,6 +506,8 @@ end
             rd_o                    <= '0;
         end
     end
+
+    assign result_fwd_o = result;
 
 //////////////////////////////////////////////////////////////////////////////
 // BRANCH CONTROL

--- a/rtl/mul.sv
+++ b/rtl/mul.sv
@@ -10,6 +10,7 @@ module mul
 (
     input   logic        clk,
     input   logic        reset_n,
+    input   logic        stall,
 
     input   logic [31:0] first_operand_i,
     input   logic [31:0] second_operand_i,
@@ -22,8 +23,11 @@ module mul
     output  logic [31:0] result_o
 );
 
-    typedef enum logic [1:0]{
-        ALBL, ALBH, AHBL, AHBH
+    typedef enum logic [3:0] {
+        ALBL = 4'b0001, 
+        ALBH = 4'b0010, 
+        AHBL = 4'b0100, 
+        AHBH = 4'b1000
     } mul_states_e;
 
     mul_states_e mul_state, next_state;
@@ -38,24 +42,37 @@ module mul
     logic        start;
     logic        signed_mult;
 
-    assign signed_mult  = (signed_mode_i != 2'b00);
-    assign result_o = mac_result_partial[31:0];
-    assign start        = (mul_state == ALBL && enable_i == 1'b1);
-
+    assign signed_mult  = (signed_mode_i != '0);
+    assign start        = enable_i && (mul_state == ALBL);
+    assign result_o     = mac_result_partial[31:0];
     assign mac_result   = $signed({sign_a, op_a}) * $signed({sign_b, op_b}) + $signed(accum);
 
+    logic hold;
+    assign hold_o = start || hold;
+
     always_ff @(posedge clk or negedge reset_n) begin
-        if (!reset_n) begin
+        if (!reset_n)
             mac_result_reg <= 0;
-        end
-        else begin
+        else if (!(((mul_state == AHBH) || (mul_state == AHBL && mul_low_i)) && stall))
             mac_result_reg <= mac_result_partial;
-        end
     end
 
-    logic hold;
+    always_comb begin
+        unique case (mul_state)
+            ALBL:    next_state = start ? ALBH : ALBL;
+            ALBH:    next_state = AHBL;
+            AHBL:    next_state = mul_low_i ? ALBL : AHBH;
+            AHBH:    next_state = ALBL;
+            default: next_state = ALBL;
+        endcase
+    end
 
-    assign hold_o = start || hold;
+    always_ff@(posedge clk or negedge reset_n) begin
+        if (!reset_n)
+            mul_state <= ALBL;
+        else if (!(((mul_state == AHBH) || (mul_state == AHBL && mul_low_i)) && stall))
+            mul_state <= next_state;
+    end
 
     always_ff @(posedge clk or negedge reset_n) begin
         if (!reset_n) begin
@@ -71,85 +88,63 @@ module mul
     end
 
     always_comb begin
-        op_a           = first_operand_i[15:0];
-        op_b           = second_operand_i[15:0];
-        accum          = mac_result_reg;
-        sign_a         = '0;
-        sign_b         = '0;
-        mac_result_partial = mac_result;
-
         unique case (mul_state)
-            ALBL: begin
-                op_a           = first_operand_i[15:0];
-                op_b           = second_operand_i[15:0];
-                sign_a         = (single_cycle_i) ? (first_operand_i [31] & signed_mode_i[0]) : 1'b0;
-                sign_b         = (single_cycle_i) ? (second_operand_i[31] & signed_mode_i[1]) : 1'b0;
-                accum          = '0;
-                mac_result_partial = mac_result;
-                if (start == 1'b1) begin
-                    next_state = ALBH;
-                end else begin
-                    next_state = ALBL;
-                end
-            end
-            ALBH: begin
-                op_a   = first_operand_i[15:0];
-                op_b   = second_operand_i[31:16];
-                sign_a = '0;
-                sign_b = (second_operand_i[31] & signed_mode_i[1]);
-
-                accum  = {19'b0, mac_result_reg[31:16]};
-
-                if (mul_low_i) begin
-                    mac_result_partial = {3'b0, mac_result[15:0], mac_result_reg[15:0]};
-                end
-                else begin
-                    mac_result_partial = mac_result;
-                end
-
-                next_state = AHBL;
-            end
-            AHBL: begin
-                op_a   = first_operand_i[31:16];
-                op_b   = second_operand_i[15:0];
-                sign_a = (first_operand_i[31] & signed_mode_i[0]);
-                sign_b = '0;
-
-                if (mul_low_i) begin
-                    accum               = {19'b0, mac_result_reg[31:16]};
-                    mac_result_partial  = {3'b0, mac_result[15:0], mac_result_reg[15:0]};
-
-                    next_state = ALBL;
-                end
-                else begin
-                    mac_result_partial = mac_result;
-                    accum      = mac_result_reg;
-                    next_state = AHBH;
-                end
-            end
-            AHBH: begin
-                op_a    = first_operand_i[31:16];
-                op_b    = second_operand_i[31:16];
-
-                sign_a  = (signed_mode_i[0] & first_operand_i[31]);
-                sign_b  = (signed_mode_i[1] & second_operand_i[31]);
-
-                accum[17:0]  = mac_result_reg[33:16];
-                accum[34:18] = {17{signed_mult & mac_result_reg[33]}};
-
-                mac_result_partial = mac_result;
-
-                next_state = ALBL;
-            end
+            ALBL,
+            ALBH:    op_a = first_operand_i[15:0];
+            AHBL,
+            AHBH:    op_a = first_operand_i[31:16];
+            default: op_a = '0;
         endcase
     end
 
-    always_ff@(posedge clk or negedge reset_n) begin
-        if (!reset_n) begin
-            mul_state <= ALBL;
-        end else begin
-            mul_state <= next_state;
-        end
+    always_comb begin
+        unique case (mul_state)
+            ALBL,
+            AHBL:    op_b = second_operand_i[15:0];
+            ALBH,
+            AHBH:    op_b = second_operand_i[31:16];
+            default: op_b = '0;
+        endcase
+    end
+
+    always_comb begin
+        unique case (mul_state)
+            ALBL:    accum = '0;
+            ALBH:    accum = {19'b0, mac_result_reg[31:16]};
+            AHBL:    accum = mul_low_i ? {19'b0, mac_result_reg[31:16]} : mac_result_reg;
+            AHBH:    accum = {{17{signed_mult && mac_result_reg[33]}}, mac_result_reg[33:16]}; 
+            default: accum = '0;
+        endcase
+    end
+
+    always_comb begin
+        unique case (mul_state)
+            ALBL:    sign_a = single_cycle_i && first_operand_i[31] && signed_mode_i[0];
+            ALBH:    sign_a = 1'b0;
+            AHBL,
+            AHBH:    sign_a = signed_mode_i[0] && first_operand_i[31];
+            default: sign_a = 1'b0;
+        endcase
+    end
+
+    always_comb begin
+        unique case (mul_state)
+            ALBL:    sign_b = single_cycle_i && second_operand_i[31] && signed_mode_i[1];
+            AHBL:    sign_b = 1'b0;
+            ALBH,
+            AHBH:    sign_b = signed_mode_i[1] && second_operand_i[31];
+            default: sign_b = 1'b0;
+        endcase
+    end
+
+    always_comb begin
+        unique case (mul_state)
+            ALBL, 
+            AHBH:    mac_result_partial = mac_result;
+            ALBH,
+            AHBL:    mac_result_partial = mul_low_i ? {3'b0, mac_result[15:0], mac_result_reg[15:0]} : mac_result;
+            default: mac_result_partial = '0;
+        endcase
     end
 
 endmodule

--- a/rtl/vectorALU.sv
+++ b/rtl/vectorALU.sv
@@ -1113,6 +1113,7 @@ module vectorALU
             mul mul32b (
                 .clk             (clk),
                 .reset_n         (reset_n),
+                .stall           (1'b0),
                 .first_operand_i (mult_op_a_32b[i_mul32b]),
                 .second_operand_i(mult_op_b_32b[i_mul32b]),
                 .signed_mode_i   (mult_signed_mode),


### PR DESCRIPTION
This PR adds data forwarding from execute result back to decode operands,  similar as in #4 .
This removes a lot of hazards.

We still have a 1-cycle hazard when a register is loaded from memory and the next instruction uses it.
This load is already forwarded from retire to decode.
Forwarding from retire to execute would eliminate this bubble but it seems unlikely to comply with timing constraints.

To allow this PR to work with BP+Compressed we had to move the decompress module to the fetch stage, thus the decoding stage is the same regardless of C/non-C. 
The timing requirements are met but with _phys_opt_ optimizations in Vivado.

CoreMark score went from 198.3 to 225.3 (+13.6%). Without BP, it went from 187.5 to 211.5 (+12.8%).