### PR TITLE
Fix system reset with branch prediction

### DIFF
--- a/rtl/RS5.sv
+++ b/rtl/RS5.sv
@@ -236,6 +236,7 @@ module RS5
         .clk                        (clk),
         .reset_n                    (reset_n),
         .enable                     (enable_decode),
+        .sys_reset                  (sys_reset_i),
         .instruction_i              (instruction_decode),
         .pc_i                       (pc_decode),
         .rs1_data_read_i            (regbank_data1),

--- a/rtl/decode.sv
+++ b/rtl/decode.sv
@@ -37,6 +37,7 @@ module decode
     input   logic           clk,
     input   logic           reset_n,
     input   logic           enable,
+    input   logic           sys_reset,
 
     input   logic [31:0]    instruction_i,
     input   logic [31:0]    pc_i,
@@ -471,6 +472,8 @@ module decode
         always_ff @(posedge clk or negedge reset_n) begin
             if (!reset_n)
                 bp_taken_o <= 1'b0;
+            else if (sys_reset)
+                bp_taken_o <= 1'b0;
             else if (enable && !hazard_o)
                 bp_taken_o <= bp_take_o;
         end
@@ -739,6 +742,9 @@ module decode
 
     always_ff @(posedge clk or negedge reset_n) begin
         if (!reset_n) begin
+            instruction_operation_o <= NOP;
+        end
+        else if (sys_reset) begin
             instruction_operation_o <= NOP;
         end
         else if (enable) begin

--- a/rtl/fetch.sv
+++ b/rtl/fetch.sv
@@ -134,8 +134,6 @@ module fetch  #(
     always_ff @(posedge clk or negedge reset_n) begin
         if (!reset_n)
             pc_jumped_r <= '0;
-        else if (sys_reset)
-            pc_jumped_r <= '0;
         else if (jumped_r)
             pc_jumped_r <= pc_jumped;
     end
@@ -151,8 +149,6 @@ module fetch  #(
     /* at the moment the instruction arrives     */
     always_ff @(posedge clk or negedge reset_n) begin
         if (!reset_n)
-            pc_o <= '0;
-        else if (sys_reset)
             pc_o <= '0;
         else if (enable_i) 
             pc_o <= pc_update;
@@ -207,8 +203,6 @@ module fetch  #(
         always_ff @(posedge clk or negedge reset_n) begin
             if (!reset_n)
                 iaddr_rollbacked <= '0;
-            else if (sys_reset)
-                iaddr_rollbacked <= '0;
             else if (enable_i && bp_take_i)
                 iaddr_rollbacked <= iaddr_not_jumped;
         end
@@ -227,8 +221,6 @@ module fetch  #(
         logic [31:0] pc_rollbacked;
         always_ff @(posedge clk or negedge reset_n) begin
             if (!reset_n)
-                pc_rollbacked <= '0;
-            else if (sys_reset)
                 pc_rollbacked <= '0;
             else if (jump_rollback_r)
                 pc_rollbacked <= pc_o;
@@ -356,8 +348,6 @@ module fetch  #(
             logic [31:0] idata_rollbacked;
             always_ff @(posedge clk or negedge reset_n) begin
                 if (!reset_n)
-                    idata_rollbacked <= 32'h00000013;
-                else if (sys_reset)
                     idata_rollbacked <= 32'h00000013;
                 else if (jump_rollback_r)
                     idata_rollbacked <= instruction_word;

--- a/rtl/fetch.sv
+++ b/rtl/fetch.sv
@@ -81,6 +81,8 @@ module fetch  #(
     always_ff @(posedge clk or negedge reset_n) begin
         if (!reset_n)
             jumped_r <= 1'b1;
+        else if (sys_reset)
+            jumped_r <= 1'b1;
         else if (jumped)
             jumped_r <= 1'b1;
         else if (enable_i || jump_rollback_i)
@@ -91,12 +93,16 @@ module fetch  #(
     always_ff @(posedge clk or negedge reset_n) begin
         if (!reset_n)
             jumped_r2 <= 1'b1;
+        else if (sys_reset)
+            jumped_r2 <= 1'b1;
         else if (enable_i)
             jumped_r2 <= jumped_r && !jump_rollback_i;
     end
     
     always_ff @(posedge clk or negedge reset_n) begin
         if (!reset_n)
+            jumping_o <= 1'b1;
+        else if (sys_reset)
             jumping_o <= 1'b1;
         else if (jumped || (jumped_r && !jump_rollback_i))
             jumping_o <= 1'b1;
@@ -118,6 +124,8 @@ module fetch  #(
     always_ff @(posedge clk or negedge reset_n) begin
         if (!reset_n)
             pc_jumped <= start_address;
+        else if (sys_reset)
+            pc_jumped <= start_address;
         else if (jumped)
             pc_jumped <= jump_target;
     end
@@ -125,6 +133,8 @@ module fetch  #(
     logic [31:0] pc_jumped_r;
     always_ff @(posedge clk or negedge reset_n) begin
         if (!reset_n)
+            pc_jumped_r <= '0;
+        else if (sys_reset)
             pc_jumped_r <= '0;
         else if (jumped_r)
             pc_jumped_r <= pc_jumped;
@@ -141,6 +151,8 @@ module fetch  #(
     /* at the moment the instruction arrives     */
     always_ff @(posedge clk or negedge reset_n) begin
         if (!reset_n)
+            pc_o <= '0;
+        else if (sys_reset)
             pc_o <= '0;
         else if (enable_i) 
             pc_o <= pc_update;
@@ -174,6 +186,8 @@ module fetch  #(
     always_ff @(posedge clk or negedge reset_n) begin
         if (!reset_n)
             instruction_o <= 32'h00000013;
+        else if (sys_reset)
+            instruction_o <= 32'h00000013;
         else if (enable_i)
             instruction_o <= instruction_next;
     end
@@ -193,12 +207,16 @@ module fetch  #(
         always_ff @(posedge clk or negedge reset_n) begin
             if (!reset_n)
                 iaddr_rollbacked <= '0;
+            else if (sys_reset)
+                iaddr_rollbacked <= '0;
             else if (enable_i && bp_take_i)
                 iaddr_rollbacked <= iaddr_not_jumped;
         end
 
         always_ff @(posedge clk or negedge reset_n) begin
             if (!reset_n)
+                jump_rollback_r <= 1'b0;
+            else if (sys_reset)
                 jump_rollback_r <= 1'b0;
             else if (jump_rollback_i)
                 jump_rollback_r <= 1'b1;
@@ -210,12 +228,16 @@ module fetch  #(
         always_ff @(posedge clk or negedge reset_n) begin
             if (!reset_n)
                 pc_rollbacked <= '0;
+            else if (sys_reset)
+                pc_rollbacked <= '0;
             else if (jump_rollback_r)
                 pc_rollbacked <= pc_o;
         end
 
         always_ff @(posedge clk or negedge reset_n) begin
             if (!reset_n)
+                bp_rollback_o <= 1'b0;
+            else if (sys_reset)
                 bp_rollback_o <= 1'b0;
             else if (enable_i)
                 bp_rollback_o <= jump_rollback_r;
@@ -334,6 +356,8 @@ module fetch  #(
             logic [31:0] idata_rollbacked;
             always_ff @(posedge clk or negedge reset_n) begin
                 if (!reset_n)
+                    idata_rollbacked <= 32'h00000013;
+                else if (sys_reset)
                     idata_rollbacked <= 32'h00000013;
                 else if (jump_rollback_r)
                     idata_rollbacked <= instruction_word;


### PR DESCRIPTION
This PR fixes some issues with sys reset that could happen with the new fetch and branch prediction implementations. Relevant signals are now reset and the decode stage emits a NOP instruction whenever there is a sys reset.