### PR TITLE
Move JAL(R) link register sum to decode for better timing

### DIFF
--- a/rtl/RS5.sv
+++ b/rtl/RS5.sv
@@ -224,6 +224,7 @@ module RS5
     logic        write_enable_exec;
     logic [31:0] result_exec;
     logic [31:0] jump_imm_target_exec;
+    logic [31:0] pc_next;
 
     decode # (
         .MULEXT    (MULEXT    ),
@@ -257,6 +258,7 @@ module RS5
         .pc_o                       (pc_execute),
         .instruction_o              (instruction_execute),
         .jump_imm_target_o          (jump_imm_target_exec),
+        .pc_next_o                  (pc_next),
         .compressed_o               (instruction_compressed_execute),
         .instruction_operation_o    (instruction_operation_execute),
         .atomic_operation_o         (atomic_operation_execute),
@@ -339,14 +341,12 @@ module RS5
         .reset_n                 (reset_n),
         .stall                   (stall),
         .instruction_i           (instruction_execute),
-        .pc_i                    (pc_execute),
         .rs1_data_i              (rs1_data_execute),
         .rs2_data_i              (rs2_data_execute),
         .second_operand_i        (second_operand_execute),
         .rd_i                    (rd_execute),
         .rs1_i                   (rs1_execute),
         .instruction_operation_i (instruction_operation_execute),
-        .instruction_compressed_i(instruction_compressed_execute),
         .atomic_operation_i      (atomic_operation_execute),
         .vector_operation_i      (vector_operation_execute),
         .privilege_i             (privilege),
@@ -381,6 +381,7 @@ module RS5
         .jump_imm_target_i       (jump_imm_target_exec),
         .reservation_data_i      (reservation_data),
         .jump_target_o           (jump_target),
+        .pc_next_i               (pc_next),
         .interrupt_pending_i     (interrupt_pending),
         .mtvec_i                 (mtvec),
         .mepc_i                  (mepc),

--- a/rtl/decode.sv
+++ b/rtl/decode.sv
@@ -62,6 +62,8 @@ module decode
     output  logic [31:0]    pc_o,
     output  logic [31:0]    instruction_o,
     output  logic [31:0]    jump_imm_target_o,
+    output  logic [31:0]    pc_next_o,
+
     output  logic           compressed_o,
     output  iType_e         instruction_operation_o,
     output  iTypeAtomic_e   atomic_operation_o,
@@ -716,7 +718,7 @@ module decode
     end
 
 //////////////////////////////////////////////////////////////////////////////
-// Outputs do execution unit
+// Outputs to execution unit
 //////////////////////////////////////////////////////////////////////////////
 
     always_ff @(posedge clk or negedge reset_n) begin
@@ -752,6 +754,16 @@ module decode
                 instruction_operation_o <= NOP;
             else
                 instruction_operation_o <= instruction_operation;
+        end
+    end
+
+    always_ff @(posedge clk or negedge reset_n) begin
+        if (!reset_n) begin
+            pc_next_o <= '0;
+        end
+        else begin
+            // To link register. Maybe we can remove this by using the PC in decode stage
+            pc_next_o <= pc_i + (compressed_i ? 32'd2 : 32'd4);
         end
     end
 

--- a/rtl/execute.sv
+++ b/rtl/execute.sv
@@ -147,22 +147,16 @@ module execute
     logic           greater_equal;
     logic           greater_equal_unsigned;
 
-    logic [31:0] first_operand;
-
-    logic [31:0] sum2_opA;
-    always_comb begin
-        unique case (instruction_operation_i)
-            default:   sum2_opA = first_operand;
-        endcase
-    end
-
     logic [31:0] sum2_opB;
     always_comb begin
         unique case (instruction_operation_i)
             SUB:       sum2_opB = -second_operand_i;
-            default:   sum2_opB = second_operand_i; // AMO_W
+            default:   sum2_opB =  second_operand_i; // AMO_W
         endcase
     end
+
+    // Can be assigned by atomic instructions or rs1_data_i
+    logic [31:0] first_operand;
 
     always_comb begin
         /* "Unmuxable" operators */
@@ -178,7 +172,7 @@ module execute
         sra_result              = $signed(rs1_data_i) >>> second_operand_i[4:0];
 
         /* "Muxable" operators */
-        sum2_result             = sum2_opA      + sum2_opB;
+        sum2_result             = first_operand + sum2_opB;
         and_result              = first_operand & second_operand_i;
         or_result               = first_operand | second_operand_i;
         xor_result              = first_operand ^ second_operand_i;


### PR DESCRIPTION
This moves the sum done for the link register in the JAL and JALR instructions to the decode stage, improving timing in the critical path.