### PR TITLE
Working on the mem_access stage

### DIFF
--- a/rtl/decode.sv
+++ b/rtl/decode.sv
@@ -47,8 +47,11 @@ module decode
     input   logic [31:0]    pc_i,
     input   logic [31:0]    rs1_data_read_i,
     input   logic [31:0]    rs2_data_read_i,
+    input   logic [31:0]    mem_access_result_i,
     input   logic [31:0]    writeback_i,
+    input   logic [ 4:0]    rd_mem_access_i,
     input   logic [ 4:0]    rd_retire_i,
+    input   logic           mem_access_we_i,
     input   logic           regbank_we_i,
     input   logic           rollback_i,
     input   logic           compressed_i,
@@ -507,9 +510,11 @@ module decode
 
     assign is_load  = (opcode == 5'b00000) || (instruction_operation == LR_W);
     assign is_store = (opcode == 5'b01000) || (instruction_operation inside {SC_W, AMO_W});
-    
+
     logic           locked_memory;
+    logic           locked_memory_r;
     logic  [4:0]    locked_register;
+    logic  [4:0]    locked_register_r;
     logic  [4:0]    rd;
 
     assign rd = instruction_i[11:7];
@@ -528,10 +533,21 @@ module decode
 
     always_ff @(posedge clk or negedge reset_n) begin
         if (!reset_n) begin
-            locked_memory <= '0;
+            locked_register_r <= '0;
+        end
+        else begin
+            locked_register_r <= locked_register;
+        end
+    end
+
+    always_ff @(posedge clk or negedge reset_n) begin
+        if (!reset_n) begin
+            locked_memory   <= '0;
+            locked_memory_r <= '0;
         end
         else if (enable) begin
-            if (hazard_o || killed) 
+            locked_memory_r <= locked_memory;
+            if (hazard_o || killed)
                 locked_memory <= '0;
             else    // Read-after-write on STORE
                 locked_memory <= is_store;
@@ -608,16 +624,16 @@ module decode
         endcase
     end
 
-    assign locked_rs1 = (locked_register != '0 && locked_register == rs1_o);
-    assign locked_rs2 = (locked_register != '0 && locked_register == rs2_o);
+    assign locked_rs1 = (locked_register != '0 && locked_register == rs1_o) || ( locked_register_r != '0 && locked_register_r == rs1_o);
+    assign locked_rs2 = (locked_register != '0 && locked_register == rs2_o) || ( locked_register_r != '0 && locked_register_r == rs2_o);
 
     /* I don't know why we should have this hazard                  */
     /* But removing this breaks the processor                       */
     /* It also breaks if we limit the hazard to same address access */
-    assign hazard_mem = locked_memory   && is_load;
+    assign hazard_mem = (locked_memory | locked_memory_r) && is_load;
 
-    assign hazard_rs1 = locked_rs1      && use_rs1;
-    assign hazard_rs2 = locked_rs2      && use_rs2;
+    assign hazard_rs1 = locked_rs1 && use_rs1;
+    assign hazard_rs2 = locked_rs2 && use_rs2;
 
     assign killed   = jump_confirmed || jump_misaligned_i || rollback_i;
     assign hazard_o = (hazard_mem || hazard_rs1 || hazard_rs2) && !killed && !exception;
@@ -667,6 +683,8 @@ module decode
         always_comb begin
             if (rs1_o == rd_o && execute_we_i)  // Forwarding from execute
                 rs1_data = result_i;
+            else if (rs1_o == rd_mem_access_i && mem_access_we_i && !locked_memory_r) // Forwarding from mem access
+                rs1_data = mem_access_result_i;
             else if (rs1_o == rd_retire_i && regbank_we_i)  // Forwarding from retire on LOAD
                 rs1_data = writeback_i;
             else
@@ -676,6 +694,8 @@ module decode
         always_comb begin
             if (rs2_o == rd_o && execute_we_i)  // Forwarding from execute
                 rs2_data = result_i;
+            else if (rs2_o == rd_mem_access_i && mem_access_we_i && !locked_memory_r) // Forwarding from mem access
+                rs2_data = mem_access_result_i;
             else if (rs2_o == rd_retire_i && regbank_we_i)  // Forwarding from retire on LOAD
                 rs2_data = writeback_i;
             else

--- a/rtl/retire.sv
+++ b/rtl/retire.sv
@@ -19,7 +19,7 @@
  * It performs the write-back on the register bank. It also receives the data read from memory
  * and process it based on instruction format then it decides which data should be sent to the
  * register bank, either the data from memory or the data from execute unit.
- * 
+ *
  */
 
 `include "RS5_pkg.sv"
@@ -54,53 +54,53 @@ module retire
         unique case (instruction_operation_i)
             LB: begin
                 case (result_i[1:0])
-                    2'b11: begin 
+                    2'b11: begin
                         memory_data[31:8] = {24{mem_data_i[31]}};
-                        memory_data[7:0]  = mem_data_i[31:24]; 
+                        memory_data[7:0]  = mem_data_i[31:24];
                     end
-                    2'b10: begin 
+                    2'b10: begin
                         memory_data[31:8] = {24{mem_data_i[23]}};
-                        memory_data[7:0]  = mem_data_i[23:16]; 
+                        memory_data[7:0]  = mem_data_i[23:16];
                     end
-                    2'b01: begin 
+                    2'b01: begin
                         memory_data[31:8] = {24{mem_data_i[15]}};
                         memory_data[7:0]  = mem_data_i[15:8];
                     end
-                    default: begin 
+                    default: begin
                         memory_data[31:8] = {24{mem_data_i[7]}};
-                        memory_data[7:0]  = mem_data_i[7:0]; 
+                        memory_data[7:0]  = mem_data_i[7:0];
                     end
                 endcase
             end
-            
+
             LBU: begin
                 memory_data[31:8] = '0;
                 case (result_i[1:0])
-                    2'b11:   memory_data[7:0]  = mem_data_i[31:24]; 
-                    2'b10:   memory_data[7:0]  = mem_data_i[23:16]; 
+                    2'b11:   memory_data[7:0]  = mem_data_i[31:24];
+                    2'b10:   memory_data[7:0]  = mem_data_i[23:16];
                     2'b01:   memory_data[7:0]  = mem_data_i[15:8];
-                    default: memory_data[7:0]  = mem_data_i[7:0]; 
+                    default: memory_data[7:0]  = mem_data_i[7:0];
                 endcase
             end
 
             LH: begin
                 case (result_i[1])
-                    1'b1: begin 
+                    1'b1: begin
                         memory_data[31:16] = {16{mem_data_i[31]}};
-                        memory_data[15:0]  = mem_data_i[31:16]; 
+                        memory_data[15:0]  = mem_data_i[31:16];
                     end
-                    default: begin  
+                    default: begin
                         memory_data[31:16] = {16{mem_data_i[15]}};
-                        memory_data[15:0]  = mem_data_i[15:0]; 
+                        memory_data[15:0]  = mem_data_i[15:0];
                     end
                 endcase
             end
 
             LHU: begin
-                memory_data[31:16] = '0; 
+                memory_data[31:16] = '0;
                 case (result_i[1])
-                    1'b1:    memory_data[15:0] = mem_data_i[31:16]; 
-                    default: memory_data[15:0] = mem_data_i[15:0]; 
+                    1'b1:    memory_data[15:0] = mem_data_i[31:16];
+                    default: memory_data[15:0] = mem_data_i[15:0];
                 endcase
             end
 
@@ -117,7 +117,7 @@ module retire
         unique case (instruction_operation_i)
             LB,LBU,LH,LHU,LW,LR_W: regbank_data_o = memory_data;
             default:               regbank_data_o = result_i;
-        endcase         
+        endcase
     end
 
 ////////////////////////////////////////////////////////////////////////////////


### PR DESCRIPTION
Seems to be passing in coremark and RISCV-Tests except the amo.

I was trying to run riscof but got the error: pkg_resources.DistributionNotFound: The 'pytest' distribution was not found and is required by riscv-isac 

So, if you can please test in the riscof I would thank you, and also provide me the info on how to run it.

Still missing: update vector to support new memory access model and atomic units.