### PR TITLE
turned off verilator lint for unused signals (cycle)

### DIFF
--- a/rtl/vector/vectorReductionTree.sv
+++ b/rtl/vector/vectorReductionTree.sv
@@ -34,7 +34,9 @@ module vectorReductionTree
     input  logic [7:0][ELEMENTS_PER_REG-1:0]     mask,
     input  logic [3:0]                           cycle_count_r,
 
+    /* verilator lint_off UNUSEDSIGNAL */
     input  logic [9:0]                           cycle,
+    /* verilator lint_on UNUSEDSIGNAL */
 
     output logic [SEW-1:0]                       result_o
 );

--- a/rtl/vector/vectorReductionTree.sv
+++ b/rtl/vector/vectorReductionTree.sv
@@ -34,6 +34,7 @@ module vectorReductionTree
     input  logic [7:0][ELEMENTS_PER_REG-1:0]     mask,
     input  logic [3:0]                           cycle_count_r,
 
+    // cycle signal is only used on multi-cycle
     /* verilator lint_off UNUSEDSIGNAL */
     input  logic [9:0]                           cycle,
     /* verilator lint_on UNUSEDSIGNAL */


### PR DESCRIPTION
turned off verilator lint for unused signals (cycle signal in vectorReductionTree.sv)
