### PR TITLE
Rework pipeline signals

### DIFF
--- a/proto/RS5/RS5.xpr
+++ b/proto/RS5/RS5.xpr
@@ -248,6 +248,13 @@
           <Attr Name="UsedIn" Val="simulation"/>
         </FileInfo>
       </File>
+      <File Path="$PPRDIR/../../rtl/mem_access.sv">
+        <FileInfo>
+          <Attr Name="UsedIn" Val="synthesis"/>
+          <Attr Name="UsedIn" Val="implementation"/>
+          <Attr Name="UsedIn" Val="simulation"/>
+        </FileInfo>
+      </File>
       <File Path="$PPRDIR/../../rtl/mmu.sv">
         <FileInfo>
           <Attr Name="UsedIn" Val="synthesis"/>
@@ -533,9 +540,7 @@
   <Runs Version="1" Minor="22">
     <Run Id="synth_1" Type="Ft3:Synth" SrcSet="sources_1" Part="xc7a100tcsg324-1" ConstrsSet="constrs_1" Description="Vivado Synthesis Defaults" AutoIncrementalCheckpoint="false" WriteIncrSynthDcp="true" State="current" Dir="$PRUNDIR/synth_1" IncludeInArchive="true" IsChild="false" AutoIncrementalDir="$PSRCDIR/utils_1/imports/synth_1" AutoRQSDir="$PSRCDIR/utils_1/imports/synth_1" ParallelReportGen="true">
       <Strategy Version="1" Minor="2">
-        <StratHandle Name="Vivado Synthesis Defaults" Flow="Vivado Synthesis 2025">
-          <Desc>Vivado Synthesis Defaults</Desc>
-        </StratHandle>
+        <StratHandle Name="Vivado Synthesis Defaults" Flow="Vivado Synthesis 2025"/>
         <Step Id="synth_design"/>
       </Strategy>
       <GeneratedRun Dir="$PRUNDIR" File="gen_run.xml"/>
@@ -545,9 +550,7 @@
     </Run>
     <Run Id="impl_1" Type="Ft2:EntireDesign" Part="xc7a100tcsg324-1" ConstrsSet="constrs_1" Description="Default settings for Implementation." AutoIncrementalCheckpoint="false" WriteIncrSynthDcp="false" State="current" Dir="$PRUNDIR/impl_1" SynthRun="synth_1" IncludeInArchive="true" IsChild="false" GenFullBitstream="true" AutoIncrementalDir="$PSRCDIR/utils_1/imports/impl_1" LaunchOptions="-jobs 24 " AutoRQSDir="$PSRCDIR/utils_1/imports/impl_1" ParallelReportGen="true">
       <Strategy Version="1" Minor="2">
-        <StratHandle Name="Vivado Implementation Defaults" Flow="Vivado Implementation 2025">
-          <Desc>Default settings for Implementation.</Desc>
-        </StratHandle>
+        <StratHandle Name="Vivado Implementation Defaults" Flow="Vivado Implementation 2025"/>
         <Step Id="init_design"/>
         <Step Id="opt_design"/>
         <Step Id="power_opt_design"/>

--- a/rtl/CSRBank.sv
+++ b/rtl/CSRBank.sv
@@ -55,20 +55,13 @@ module CSRBank
     input   logic [31:0]        data_i,
     output  logic [31:0]        data_o,
 
-    /* Signals enabled with ZIHPM */
-    /* verilator lint_off UNUSEDSIGNAL */
-    input   logic               instruction_compressed_i,
-    input   iType_e             instruction_operation_i,
-    input   iTypeVector_e       vector_operation_i,
+    input   exec_ctrl_t         ctrl_i,
 
-    input   logic               hazard,
     input   logic               stall,
     input   logic               hold,
-    input   logic               killed,
 
     input   logic [31:0]        vtype_i,
     input   logic [31:0]        vlen_i,
-    /* verilator lint_on UNUSEDSIGNAL */
 
     input   logic               raise_exception_i,
     input   logic               machine_return_i,
@@ -421,7 +414,7 @@ module CSRBank
         else if (sys_reset)
             minstret <= '0;
         else begin
-            if (!mcountinhibit[2] && !(hold || instruction_operation_i == NOP))
+            if (!mcountinhibit[2] && !(hold || ctrl_i.is_nop))
                 minstret <= minstret + 1'b1;
 
             if (write_enable_i) begin
@@ -481,7 +474,7 @@ module CSRBank
             else if (sys_reset)
                 cntr_killed <= '0;
             else begin
-                if (!mcountinhibit[3] && killed)
+                if (!mcountinhibit[3] && ctrl_i.killed)
                     cntr_killed <= cntr_killed + 1'b1;
 
                 if (write_enable_i && address_i == MHPMCOUNTER3)
@@ -495,7 +488,7 @@ module CSRBank
             else if (sys_reset)
                 cntr_scalar <= '0;
             else begin
-                if (!mcountinhibit[3] && !(instruction_operation_i inside {NOP, VECTOR, VLOAD, VSTORE}))
+                if (!mcountinhibit[3] && !(ctrl_i.is_nop || ctrl_i.is_vector))
                     cntr_scalar <= cntr_scalar + 1'b1;
 
                 if (write_enable_i && address_i == MHPMCOUNTER3H)
@@ -551,7 +544,7 @@ module CSRBank
             else if (sys_reset)
                 cntr_hazard <= '0;
             else begin
-                if (!mcountinhibit[7] && hazard && !hold)
+                if (!mcountinhibit[7] && ctrl_i.hazard && !hold)
                     cntr_hazard <= cntr_hazard + 1'b1;
 
                 if (write_enable_i && address_i == MHPMCOUNTER7)
@@ -579,7 +572,7 @@ module CSRBank
             else if (sys_reset)
                 cntr_nop <= '0;
             else begin
-                if (!mcountinhibit[9] && (!hold && instruction_operation_i inside {NOP}))
+                if (!mcountinhibit[9] && (!hold && ctrl_i.is_nop))
                     cntr_nop <= cntr_nop + 1'b1;
 
                 if (write_enable_i && address_i == MHPMCOUNTER9)
@@ -593,7 +586,7 @@ module CSRBank
             else if (sys_reset)
                 cntr_logic <= '0;
             else begin
-                if (!mcountinhibit[10] && (!hold && instruction_operation_i inside {XOR, OR, AND}))
+                if (!mcountinhibit[10] && (!hold && (ctrl_i.is_xor || ctrl_i.is_or || ctrl_i.is_and)))
                     cntr_logic <= cntr_logic + 1'b1;
 
                 if (write_enable_i && address_i == MHPMCOUNTER10)
@@ -607,7 +600,7 @@ module CSRBank
             else if (sys_reset)
                 cntr_addsub <= '0;
             else begin
-                if (!mcountinhibit[11] && (!hold && instruction_operation_i inside {ADD, SUB}))
+                if (!mcountinhibit[11] && (!hold && (ctrl_i.is_add || ctrl_i.is_sub)))
                     cntr_addsub <= cntr_addsub + 1'b1;
 
                 if (write_enable_i && address_i == MHPMCOUNTER11)
@@ -621,7 +614,7 @@ module CSRBank
             else if (sys_reset)
                 cntr_shift <= '0;
             else begin
-                if (!mcountinhibit[12] && (!hold && instruction_operation_i inside {SLL, SRL, SRA}))
+                if (!mcountinhibit[12] && (!hold && (ctrl_i.is_sll || ctrl_i.is_srl || ctrl_i.is_sra)))
                     cntr_shift <= cntr_shift + 1'b1;
 
                 if (write_enable_i && address_i == MHPMCOUNTER12)
@@ -635,7 +628,7 @@ module CSRBank
             else if (sys_reset)
                 cntr_branch <= '0;
             else begin
-                if (!mcountinhibit[13] && (!hold && instruction_operation_i inside {BEQ, BNE, BLT, BLTU, BGE, BGEU}))
+                if (!mcountinhibit[13] && (!hold && (ctrl_i.is_beq || ctrl_i.is_bne || ctrl_i.is_blt || ctrl_i.is_bltu || ctrl_i.is_bge || ctrl_i.is_bgeu)))
                     cntr_branch <= cntr_branch + 1'b1;
 
                 if (write_enable_i && address_i == MHPMCOUNTER13)
@@ -649,7 +642,7 @@ module CSRBank
             else if (sys_reset)
                 cntr_jump <= '0;
             else begin
-                if (!mcountinhibit[14] && (!hold && instruction_operation_i inside {JAL, JALR}))
+                if (!mcountinhibit[14] && (!hold && ctrl_i.is_jal_jalr))
                     cntr_jump <= cntr_jump + 1'b1;
 
                 if (write_enable_i && address_i == MHPMCOUNTER14)
@@ -663,7 +656,7 @@ module CSRBank
             else if (sys_reset)
                 cntr_load <= '0;
             else begin
-                if (!mcountinhibit[15] && (!hold && instruction_operation_i inside {LB, LBU, LH, LHU, LW}))
+                if (!mcountinhibit[15] && (!hold && ctrl_i.is_load))
                     cntr_load <= cntr_load + 1'b1;
 
                 if (write_enable_i && address_i == MHPMCOUNTER15)
@@ -677,7 +670,7 @@ module CSRBank
             else if (sys_reset)
                 cntr_store <= '0;
             else begin
-                if (!mcountinhibit[16] && (!hold && instruction_operation_i inside {SB, SH, SW}))
+                if (!mcountinhibit[16] && (!hold && ctrl_i.is_store))
                     cntr_store <= cntr_store + 1'b1;
 
                 if (write_enable_i && address_i == MHPMCOUNTER16)
@@ -691,7 +684,7 @@ module CSRBank
             else if (sys_reset)
                 cntr_sys <= '0;
             else begin
-                if (!mcountinhibit[17] && (!hold && instruction_operation_i inside {MRET, WFI, ECALL, EBREAK}))
+                if (!mcountinhibit[17] && (!hold && (ctrl_i.is_mret || ctrl_i.is_wfi || ctrl_i.is_ecall || ctrl_i.is_ebreak)))
                     cntr_sys <= cntr_sys + 1'b1;
 
                 if (write_enable_i && address_i == MHPMCOUNTER17)
@@ -708,7 +701,7 @@ module CSRBank
                 if (
                         !mcountinhibit[18] && 
                         (
-                            !hold && instruction_operation_i inside {CSRRW, CSRRWI, CSRRS, CSRRSI, CSRRC, CSRRCI}
+                            !hold && ctrl_i.is_csr
                         )
                     )
                     cntr_csr <= cntr_csr + 1'b1;
@@ -724,7 +717,7 @@ module CSRBank
             else if (sys_reset)
                 cntr_luislt <= '0;
             else begin
-                if (!mcountinhibit[19] && (!hold && instruction_operation_i inside {SLTU, SLT, LUI}))
+                if (!mcountinhibit[19] && (!hold && (ctrl_i.is_sltu || ctrl_i.is_slt || ctrl_i.is_lui)))
                     cntr_luislt <= cntr_luislt + 1'b1;
 
                 if (write_enable_i && address_i == MHPMCOUNTER19)
@@ -739,7 +732,7 @@ module CSRBank
                 else if (sys_reset)
                     cntr_compressed <= '0;
                 else begin
-                    if (!mcountinhibit[20] && (!hold && instruction_compressed_i))
+                    if (!mcountinhibit[20] && (!hold && ctrl_i.compressed))
                         cntr_compressed <= cntr_compressed + 1'b1;
 
                     if (write_enable_i && address_i == MHPMCOUNTER20)
@@ -753,7 +746,7 @@ module CSRBank
                 else if (sys_reset)
                     cntr_misaligned <= '0;
                 else begin
-                    if (!mcountinhibit[21] && (!stall && !hold && !hazard && jump_misaligned_i))
+                    if (!mcountinhibit[21] && (!stall && !hold && !ctrl_i.hazard && jump_misaligned_i))
                         cntr_misaligned <= cntr_misaligned + 1'b1;
 
                     if (write_enable_i && address_i == MHPMCOUNTER21)
@@ -773,7 +766,7 @@ module CSRBank
                 else if (sys_reset)
                     cntr_mul <= '0;
                 else begin
-                    if (!mcountinhibit[22] && (!hold && instruction_operation_i inside {MUL, MULH, MULHU, MULHSU}))
+                    if (!mcountinhibit[22] && (!hold && ctrl_i.is_mul))
                         cntr_mul <= cntr_mul + 1'b1;
 
                     if (write_enable_i && address_i == MHPMCOUNTER22)
@@ -792,7 +785,7 @@ module CSRBank
                 else if (sys_reset)
                     cntr_div <= '0;
                 else begin
-                    if (!mcountinhibit[23] && (!hold && instruction_operation_i inside {DIV, DIVU, REM, REMU}))
+                    if (!mcountinhibit[23] && (!hold && (ctrl_i.is_div || ctrl_i.is_rem)))
                         cntr_div <= cntr_div + 1'b1;
 
                     if (write_enable_i && address_i == MHPMCOUNTER23)
@@ -815,8 +808,8 @@ module CSRBank
                             !mcountinhibit[24] && 
                             (
                                 !hold && 
-                                instruction_operation_i inside {VECTOR} && 
-                                vector_operation_i inside {VADD, VSUB, VRSUB}
+                                (ctrl_i.is_vector && !ctrl_i.is_vector_mem) && 
+                                ctrl_i.vector_op inside {VADD, VSUB, VRSUB}
                             )
                         )
                         cntr_vaddsub <= cntr_vaddsub + 1'b1;
@@ -836,7 +829,7 @@ module CSRBank
                             !mcountinhibit[24] &&
                             (
                                 !hold &&
-                                instruction_operation_i inside {VECTOR, VLOAD, VSTORE}
+                                ctrl_i.is_vector
                             )
                         )
                         cntr_vinst <= cntr_vinst + 1'b1;
@@ -856,8 +849,8 @@ module CSRBank
                             !mcountinhibit[25] && 
                             (
                                 !hold && 
-                                instruction_operation_i inside {VECTOR} && 
-                                vector_operation_i inside {VMUL, VMULH, VMULHU, VMULHSU, VWMUL, VWMULU, VWMULSU}
+                                (ctrl_i.is_vector && !ctrl_i.is_vector_mem) && 
+                                ctrl_i.vector_op inside {VMUL, VMULH, VMULHU, VMULHSU, VWMUL, VWMULU, VWMULSU}
                             )
                         )
                         cntr_vmul <= cntr_vmul + 1'b1;
@@ -875,7 +868,7 @@ module CSRBank
                 else begin
                     if (
                             !mcountinhibit[25] &&
-                            instruction_operation_i == VECTOR
+                            (ctrl_i.is_vector && !ctrl_i.is_vector_mem)
                         )
                         cntr_vcycles <= cntr_vcycles + 1'b1;
 
@@ -894,8 +887,8 @@ module CSRBank
                             !mcountinhibit[26] && 
                             (
                                 !hold && 
-                                instruction_operation_i inside {VECTOR} && 
-                                vector_operation_i inside {VDIV, VDIVU, VREM, VREMU}
+                                (ctrl_i.is_vector && !ctrl_i.is_vector_mem) && 
+                                ctrl_i.vector_op inside {VDIV, VDIVU, VREM, VREMU}
                             )
                         )
                         cntr_vdiv <= cntr_vdiv + 1'b1;
@@ -915,8 +908,8 @@ module CSRBank
                             !mcountinhibit[27] && 
                             (
                                 !hold && 
-                                instruction_operation_i inside {VECTOR} && 
-                                vector_operation_i inside {VMACC, VNMSAC, VMADD, VNMSUB}
+                                (ctrl_i.is_vector && !ctrl_i.is_vector_mem) && 
+                                ctrl_i.vector_op inside {VMACC, VNMSAC, VMADD, VNMSUB}
                             )
                         )
                         cntr_vmac <= cntr_vmac + 1'b1;
@@ -936,8 +929,8 @@ module CSRBank
                             !mcountinhibit[28] && 
                             (
                                 !hold && 
-                                instruction_operation_i inside {VECTOR} && 
-                                vector_operation_i inside {VREDMIN, VREDMINU, VREDMAX, VREDMAXU}
+                                (ctrl_i.is_vector && !ctrl_i.is_vector_mem) && 
+                                ctrl_i.vector_op inside {VREDMIN, VREDMINU, VREDMAX, VREDMAXU}
                             )
                         )
                         cntr_vred <= cntr_vred + 1'b1;
@@ -953,7 +946,7 @@ module CSRBank
                 else if (sys_reset)
                     cntr_vloadstore <= '0;
                 else begin
-                    if (!mcountinhibit[29] && (!hold && instruction_operation_i inside {VLOAD, VSTORE}))
+                    if (!mcountinhibit[29] && (!hold && ctrl_i.is_vector_mem))
                         cntr_vloadstore <= cntr_vloadstore + 1'b1;
 
                     if (write_enable_i && address_i == MHPMCOUNTER29)
@@ -967,7 +960,7 @@ module CSRBank
                 else if (sys_reset)
                     cntr_vlscycles <= '0;
                 else begin
-                    if (!mcountinhibit[29] && (instruction_operation_i inside {VLOAD, VSTORE}))
+                    if (!mcountinhibit[29] && (ctrl_i.is_vector_mem))
                         cntr_vlscycles <= cntr_vlscycles + 1'b1;
 
                     if (write_enable_i && address_i == MHPMCOUNTER29H)
@@ -985,8 +978,8 @@ module CSRBank
                             !mcountinhibit[30] && 
                             (
                                 !hold && 
-                                instruction_operation_i inside {VECTOR} && 
-                                vector_operation_i inside {
+                                (ctrl_i.is_vector && !ctrl_i.is_vector_mem) && 
+                                ctrl_i.vector_op inside {
                                     VMSEQ, VMSNE, VMSLTU, VMSLT, VMSLEU, VMSLE, VMSGTU, VMSGT,  // mask compares
                                     VREDAND, VREDOR, VREDXOR,                                   // logic reduction
                                     VMV, VMVR, VMVSX, VMVXS,                                    // register moves

--- a/rtl/CSRBank.sv
+++ b/rtl/CSRBank.sv
@@ -55,9 +55,11 @@ module CSRBank
     input   logic [31:0]        data_i,
     output  logic [31:0]        data_o,
 
+    /* Some bits of the control signals are not used depending on the ISEs */
+    /* verilator lint_off UNUSEDSIGNAL */
     input   exec_ctrl_t         ctrl_i,
-
     input   logic               stall,
+    /* verilator lint_on UNUSEDSIGNAL */
     input   logic               hold,
 
     input   logic [31:0]        vtype_i,

--- a/rtl/RS5.sv
+++ b/rtl/RS5.sv
@@ -76,112 +76,72 @@ module RS5
     input  logic [BUS_WIDTH-1:0]    mem_data_i
 );
 
-//////////////////////////////////////////////////////////////////////////////
-// Global signals
-//////////////////////////////////////////////////////////////////////////////
+/////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+//////////////////////////////////////////////////////////// FETCH //////////////////////////////////////////////////////////////////////////////////
+/////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 
-    logic            jump;
-    logic            hazard;
-    logic            fetch_hazard;
-    logic            hold;
+    logic                hold;
+    logic                fetch_hazard;
 
-    logic            mmu_inst_fault;
-    logic            mmu_data_fault;
+    logic                enable_fetch;
+
+    logic                jump, ctx_switch, should_jump;
+    logic         [31:0] jump_target, ctx_switch_target;
+
+    logic                bp_take_fetch, jump_rollback, bp_ack;
+    logic         [31:0] bp_target;
+
+    logic         [31:0] instruction_address;
+
+    decode_ctrl_t        decode_ctrl;
+    logic         [31:0] instruction_decode, pc_decode;
+
+    assign enable_fetch  = !(stall || hold || fetch_hazard);
+
+    fetch #(
+        .start_address(START_ADDR ),
+        .IQUEUE_SIZE  (IQUEUE_SIZE),
+        .MULEXT       (MULEXT     ),
+        .ZCBEnable    (ZCBEnable  ),
+        .COMPRESSED   (COMPRESSED ),
+        .BRANCHPRED   (BRANCHPRED )
+    ) fetch1 (
+        .clk                  (clk                    ),
+        .reset_n              (reset_n                ),
+        .sys_reset            (sys_reset_i            ),
+        .enable_i             (enable_fetch           ),
+
+        .jump_i               (jump                   ),
+        .ctx_switch_i         (ctx_switch             ),
+        .should_jump_i        (should_jump            ),
+        .jump_target_i        (jump_target            ),
+        .ctx_switch_target_i  (ctx_switch_target      ),
+
+        .bp_take_i            (bp_take_fetch          ),
+        .bp_target_i          (bp_target              ),
+        .jump_rollback_i      (jump_rollback          ),
+        .bp_ack_o             (bp_ack                 ),
+
+        .mem_operation_en_o   (imem_operation_enable_o),
+        .busy_i               (busy_i                 ),
+        .instruction_address_o(instruction_address    ),
+        .instruction_data_i   (instruction_i          ),
+
+        .ctrl_o               (decode_ctrl            ),
+        .instruction_o        (instruction_decode     ),
+        .pc_o                 (pc_decode              )
+    );
 
     privilegeLevel_e privilege;
-    logic   [31:0]   jump_target;
-
-    logic                   mem_enable;
-    logic [31:0]            mem_address_exec;
-    logic [31:0]            instruction_address;
-
-    /* We always mask the two lsbs */
-    /* verilator lint_off UNUSEDSIGNAL */
-    logic   [31:0]   mem_address;
-    /* verilator lint_on UNUSEDSIGNAL */
-
-//////////////////////////////////////////////////////////////////////////////
-// Fetch signals
-//////////////////////////////////////////////////////////////////////////////
-
-    logic           enable_fetch;
-
-//////////////////////////////////////////////////////////////////////////////
-// Decoder signals
-//////////////////////////////////////////////////////////////////////////////
-
-    logic   [31:0]  pc_decode;
-    logic           enable_decode;
-    logic           jump_misaligned;
-
-//////////////////////////////////////////////////////////////////////////////
-// RegBank signals
-//////////////////////////////////////////////////////////////////////////////
-
-    logic    [4:0]  rs1, rs2;
-    logic   [31:0]  regbank_data1, regbank_data2;
-    logic    [4:0]  rd_retire;
-    logic   [31:0]  regbank_data_writeback;
-    logic           regbank_write_enable;
-
-//////////////////////////////////////////////////////////////////////////////
-// Execute signals
-//////////////////////////////////////////////////////////////////////////////
-
-    iType_e         instruction_operation_execute;
-    iTypeAtomic_e   atomic_operation_execute;
-    iTypeVector_e   vector_operation_execute;
-    logic   [31:0]  rs1_data_execute, rs2_data_execute, second_operand_execute;
-    logic   [31:0]  instruction_execute;
-    logic   [31:0]  pc_execute;
-    logic    [4:0]  rd_execute;
-    logic    [4:0]  rs1_execute;
-    logic           exc_ilegal_inst_execute;
-    logic           exc_inst_access_fault_execute;
-    logic           instruction_compressed_execute;
-    logic   [31:0]  vtype, vlen;
-
-//////////////////////////////////////////////////////////////////////////////
-// Mem Access Signals
-//////////////////////////////////////////////////////////////////////////////
-
-    iType_e         instruction_operation_mem_access;
-    logic   [31:0]  result_mem_access;
-    logic    [4:0]  rd_mem_access;
-    logic           write_enable_mem_access;
-
-
-//////////////////////////////////////////////////////////////////////////////
-// Retire signals
-//////////////////////////////////////////////////////////////////////////////
-
-    iType_e         instruction_operation_retire;
-    logic   [31:0]  result_retire;
-    logic           killed;
-
-//////////////////////////////////////////////////////////////////////////////
-// CSR Bank signals
-//////////////////////////////////////////////////////////////////////////////
-
-    logic           csr_read_enable, csr_write_enable;
-    csrOperation_e  csr_operation;
-    logic   [11:0]  csr_addr;
-    logic   [31:0]  csr_data_to_write, csr_data_read;
-    logic   [31:0]  mepc, mtvec;
-    logic           RAISE_EXCEPTION, MACHINE_RETURN;
-    logic           interrupt_pending;
-    exceptionCode_e Exception_Code;
 
     /* Signals enabled with XOSVM */
     /* verilator lint_off UNUSEDSIGNAL */
-    logic   [31:0]  mvmdo, mvmio, mvmds, mvmis, mvmdm, mvmim;
-    logic           mvmctl;
-    logic           mmu_en;
+    logic            mmu_en;
+    logic            mvmctl;
+    logic     [31:0] mvmio, mvmis, mvmim;
     /* verilator lint_on UNUSEDSIGNAL */
 
-//////////////////////////////////////////////////////////////////////////////
-// Assigns
-//////////////////////////////////////////////////////////////////////////////
+    logic            mmu_inst_fault;
 
     if (XOSVMEnable == 1'b1) begin : gen_xosvm_mmu_on
         assign mmu_en = privilege != privilegeLevel_e'(2'b11) && mvmctl == 1'b1;
@@ -189,58 +149,6 @@ module RS5
     else begin : gen_xosvm_mmu_off
         assign mmu_en = 1'b0;
     end
-
-    assign enable_fetch  = !(stall || hold || fetch_hazard);
-    assign enable_decode = !(stall || hold);
-
-/////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
-//////////////////////////////////////////////////////////// FETCH //////////////////////////////////////////////////////////////////////////////////
-/////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
-
-    logic        bp_ack;
-    logic        valid_fetch;
-    logic        should_jump;
-    logic        jump_rollback;
-    logic        jumping;
-    logic        ctx_switch;
-    logic        bp_take_fetch;
-    logic        compressed_decode;
-    logic [31:0] bp_target;
-    logic [31:0] ctx_switch_target;
-    logic [31:0] instruction_decode;
-
-    fetch #(
-        .start_address(START_ADDR),
-        .IQUEUE_SIZE  (IQUEUE_SIZE),
-        .MULEXT       (MULEXT),
-        .ZCBEnable    (ZCBEnable),
-        .COMPRESSED   (COMPRESSED),
-        .BRANCHPRED   (BRANCHPRED)
-    ) fetch1 (
-        .clk                  (clk                    ),
-        .reset_n              (reset_n                ),
-        .sys_reset            (sys_reset_i            ),
-        .enable_i             (enable_fetch           ),
-        .busy_i               (busy_i                 ),
-        .valid_o              (valid_fetch            ),
-        .bp_ack_o             (bp_ack                 ),
-        .jump_i               (jump                   ),
-        .should_jump_i        (should_jump            ),
-        .jump_rollback_i      (jump_rollback          ),
-        .jump_target_i        (jump_target            ),
-        .ctx_switch_i         (ctx_switch             ),
-        .ctx_switch_target_i  (ctx_switch_target      ),
-        .bp_take_i            (bp_take_fetch          ),
-        .bp_target_i          (bp_target              ),
-        .jumping_o            (jumping                ),
-        .jump_misaligned_o    (jump_misaligned        ),
-        .compressed_o         (compressed_decode      ),
-        .mem_operation_en_o   (imem_operation_enable_o),
-        .instruction_address_o(instruction_address    ),
-        .instruction_data_i   (instruction_i          ),
-        .instruction_o        (instruction_decode     ),
-        .pc_o                 (pc_decode              )
-    );
 
     if (XOSVMEnable == 1'b1) begin : gen_xosvm_i_mmu_on
         mmu i_mmu (
@@ -262,10 +170,26 @@ module RS5
 /////////////////////////////////////////////////////////// DECODER /////////////////////////////////////////////////////////////////////////////////
 /////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 
-    logic        bp_taken_exec;
-    logic        write_enable_exec;
-    logic [31:0] result_exec;
-    logic [31:0] jump_imm_target_exec;
+    logic               enable_decode;
+
+    logic         [4:0] rs1, rs2;
+    logic        [31:0] regbank_data1, regbank_data2;
+
+    wb_ctrl_t           ctrl_mem_access, ctrl_retire;
+    logic               write_enable_exec;
+    logic         [4:0] rd_mem_access, rd_retire;
+    logic        [31:0] result_exec, result_mem_access, regbank_data_writeback;
+
+    exec_ctrl_t          ctrl_execute;
+    logic          [4:0] rd_execute, rs1_execute;
+    logic         [11:0] csr_addr;
+    logic         [31:0] pc_execute, rs1_data_execute, rs2_data_execute;
+    logic         [31:0] second_operand_execute, instruction_execute, jump_imm_target_exec;
+    iType_e              instruction_operation_execute;
+    iTypeVector_e        vector_operation_execute;
+
+
+    assign enable_decode = !(stall || hold);
 
     decode # (
         .MULEXT       (MULEXT      ),
@@ -280,52 +204,50 @@ module RS5
         .BRANCHPRED   (BRANCHPRED  ),
         .FORWARDING   (FORWARDING  )
     ) decoder1 (
-        .clk                        (clk),
-        .reset_n                    (reset_n),
-        .enable                     (enable_decode),
-        .sys_reset                  (sys_reset_i),
-        .valid_i                    (valid_fetch),
-        .instruction_i              (instruction_decode),
-        .pc_i                       (pc_decode),
-        .rs1_data_read_i            (regbank_data1),
-        .rs2_data_read_i            (regbank_data2),
-        .rd_mem_access_i            (rd_mem_access),
-        .rd_retire_i                (rd_retire),
-        .mem_access_result_i        (result_mem_access),
-        .writeback_i                (regbank_data_writeback),
-        .result_i                   (result_exec),
-        .mem_access_we_i            (write_enable_mem_access),
-        .regbank_we_i               (regbank_write_enable),
-        .execute_we_i               (write_enable_exec),
-        .rs1_o                      (rs1),
-        .rs2_o                      (rs2),
-        .rd_o                       (rd_execute),
-        .instr_rs1_o                (rs1_execute),
-        .csr_address_o              (csr_addr),
-        .rs1_data_o                 (rs1_data_execute),
-        .rs2_data_o                 (rs2_data_execute),
-        .second_operand_o           (second_operand_execute),
-        .pc_o                       (pc_execute),
-        .instruction_o              (instruction_execute),
-        .jump_imm_target_o          (jump_imm_target_exec),
-        .compressed_o               (instruction_compressed_execute),
+        .clk                        (clk                          ),
+        .reset_n                    (reset_n                      ),
+        .enable                     (enable_decode                ),
+        .sys_reset                  (sys_reset_i                  ),
+
+        .ctrl_i                     (decode_ctrl                  ),
+        .pc_i                       (pc_decode                    ),
+        .instruction_i              (instruction_decode           ),
+
+        .should_jump_i              (should_jump                  ),
+        .jump_rollback_i            (jump_rollback                ),
+        
+        .exc_inst_access_fault_i    (mmu_inst_fault               ),
+
+        .rs1_o                      (rs1                          ),
+        .rs2_o                      (rs2                          ),
+        .rs1_data_read_i            (regbank_data1                ),
+        .rs2_data_read_i            (regbank_data2                ),
+
+        .execute_we_i               (write_enable_exec            ),
+        .mem_access_we_i            (ctrl_mem_access.rd_we        ),
+        .regbank_we_i               (ctrl_retire.rd_we            ),
+        .rd_mem_access_i            (rd_mem_access                ),
+        .rd_retire_i                (rd_retire                    ),
+        .result_i                   (result_exec                  ),
+        .mem_access_result_i        (result_mem_access            ),
+        .writeback_i                (regbank_data_writeback       ),
+
+        .dec_hazard_o               (fetch_hazard                 ),
+        .bp_take_o                  (bp_take_fetch                ),
+        .bp_target_o                (bp_target                    ),
+
+        .ctrl_o                     (ctrl_execute                 ),
+        .rd_o                       (rd_execute                   ),
+        .instr_rs1_o                (rs1_execute                  ),
+        .csr_address_o              (csr_addr                     ),
+        .pc_o                       (pc_execute                   ),
+        .rs1_data_o                 (rs1_data_execute             ),
+        .rs2_data_o                 (rs2_data_execute             ),
+        .second_operand_o           (second_operand_execute       ),
+        .instruction_o              (instruction_execute          ),
+        .jump_imm_target_o          (jump_imm_target_exec         ),
         .instruction_operation_o    (instruction_operation_execute),
-        .atomic_operation_o         (atomic_operation_execute),
-        .vector_operation_o         (vector_operation_execute),
-        .dec_hazard_o               (fetch_hazard),
-        .hazard_o                   (hazard),
-        .killed_o                   (killed),
-        .should_jump_i              (should_jump),
-        .jumping_i                  (jumping),
-        .jump_rollback_i            (jump_rollback),
-        .compressed_i               (compressed_decode),
-        .jump_misaligned_i          (jump_misaligned),
-        .bp_take_o                  (bp_take_fetch),
-        .bp_taken_o                 (bp_taken_exec),
-        .bp_target_o                (bp_target),
-        .exc_inst_access_fault_i    (mmu_inst_fault),
-        .exc_inst_access_fault_o    (exc_inst_access_fault_execute),
-        .exc_ilegal_inst_o          (exc_ilegal_inst_execute)
+        .vector_operation_o         (vector_operation_execute     )
     );
 
 /////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
@@ -334,21 +256,21 @@ module RS5
 
     if (Environment == FPGA) begin :RegFileFPGA_blk
         DRAM_RegBank RegBankA (
-            .clk        (clk),
-            .we         (regbank_write_enable),
-            .a          (rd_retire),
+            .clk        (clk                   ),
+            .we         (ctrl_retire.rd_we     ),
+            .a          (rd_retire             ),
             .d          (regbank_data_writeback),
-            .dpra       (rs1),
-            .dpo        (regbank_data1)
+            .dpra       (rs1                   ),
+            .dpo        (regbank_data1         )
         );
 
         DRAM_RegBank RegBankB (
-            .clk        (clk),
-            .we         (regbank_write_enable),
-            .a          (rd_retire),
+            .clk        (clk                   ),
+            .we         (ctrl_retire.rd_we     ),
+            .a          (rd_retire             ),
             .d          (regbank_data_writeback),
-            .dpra       (rs2),
-            .dpo        (regbank_data2)
+            .dpra       (rs2                   ),
+            .dpo        (regbank_data2         )
         );
     end
     else begin : RegFileFF_blk
@@ -358,28 +280,42 @@ module RS5
             .DBG_FILE   (DBG_REG_FILE)
         `endif
         ) regbankff (
-            .clk        (clk),
-            .reset_n    (reset_n),
-            .rs1        (rs1),
-            .rs2        (rs2),
-            .rd         (rd_retire),
-            .enable     (regbank_write_enable),
+            .clk        (clk                   ),
+            .reset_n    (reset_n               ),
+            .rs1        (rs1                   ),
+            .rs2        (rs2                   ),
+            .rd         (rd_retire             ),
+            .enable     (ctrl_retire.rd_we     ),
             .data_i     (regbank_data_writeback),
-            .data1_o    (regbank_data1),
-            .data2_o    (regbank_data2)
+            .data1_o    (regbank_data1         ),
+            .data2_o    (regbank_data2         )
         );
     end
 
 /////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 /////////////////////////////////////////////////////////// EXECUTE /////////////////////////////////////////////////////////////////////////////////
 /////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+    
+    logic                  exec_valid;
 
-    logic [31:0] reservation_data;
-    logic [31:0] pc_irq;
-    logic [31:0] pc_exc;
-    logic        exec_valid;
-    logic        load_access_fault;
-    assign exec_valid = !(killed || hazard);
+    logic                  load_access_fault;
+    logic           [31:0] reservation_data;
+
+    csrOperation_e         csr_operation;
+    exceptionCode_e        Exception_Code;
+    logic                  interrupt_pending, csr_read_enable, csr_write_enable;
+    logic                  RAISE_EXCEPTION, MACHINE_RETURN;
+    logic           [31:0] csr_data_to_write, csr_data_read;
+    logic           [31:0] mepc, mtvec, vtype, vlen, pc_irq, pc_exc;
+
+    logic                   mem_enable;
+    logic            [31:0] mem_address_exec;
+    /* We always mask the two lsbs */
+    /* verilator lint_off UNUSEDSIGNAL */
+    logic            [31:0] mem_address;
+    /* verilator lint_on UNUSEDSIGNAL */
+
+    assign exec_valid = !(ctrl_execute.killed || ctrl_execute.hazard);
 
     execute #(
         .Environment  (Environment ),
@@ -397,124 +333,124 @@ module RS5
         .BUS_WIDTH    (BUS_WIDTH   ),
         .BRANCHPRED   (BRANCHPRED  )
     ) execute1 (
-        .clk                     (clk),
-        .reset_n                 (reset_n),
-        .stall                   (stall),
-        .bp_ack_i                (bp_ack),
-        .instruction_i           (instruction_execute),
-        .rs1_data_i              (rs1_data_execute),
-        .rs2_data_i              (rs2_data_execute),
-        .second_operand_i        (second_operand_execute),
-        .rd_i                    (rd_execute),
-        .rs1_i                   (rs1_execute),
+        .clk                     (clk                          ),
+        .reset_n                 (reset_n                      ),
+        .stall                   (stall                        ),
+
+        .ctrl_i                  (ctrl_execute                 ),
+        .valid_i                 (exec_valid                   ),
+        .bp_ack_i                (bp_ack                       ),
+        .rd_i                    (rd_execute                   ),
+        .rs1_i                   (rs1_execute                  ),
+        .csr_address_i           (csr_addr                     ),
+        .pc_i                    (pc_execute                   ),
+        .rs1_data_i              (rs1_data_execute             ),
+        .rs2_data_i              (rs2_data_execute             ),
+        .second_operand_i        (second_operand_execute       ),
+        .jump_imm_target_i       (jump_imm_target_exec         ),
+        .instruction_i           (instruction_execute          ),
         .instruction_operation_i (instruction_operation_execute),
-        .atomic_operation_i      (atomic_operation_execute),
-        .vector_operation_i      (vector_operation_execute),
-        .privilege_i             (privilege),
-        .valid_i                 (exec_valid),
-        .exc_ilegal_inst_i       (exc_ilegal_inst_execute),
-        .exc_inst_access_fault_i (exc_inst_access_fault_execute),
-        .exc_load_access_fault_i (load_access_fault),
-        .hold_o                  (hold),
-        .write_enable_o          (write_enable_mem_access),
-        .write_enable_fwd_o      (write_enable_exec),
-        .instruction_operation_o (instruction_operation_mem_access),
-        .result_o                (result_mem_access),
-        .result_fwd_o            (result_exec),
-        .rd_o                    (rd_mem_access),
-        .mem_address_exec_o      (mem_address_exec),
-        .mem_address_o           (mem_address),
-        .mem_enable_o            (mem_enable),
-        .mem_write_enable_o      (mem_write_enable_o),
-        .mem_write_data_o        (mem_data_o),
-        .mem_read_data_i         (mem_data_i),
-        .csr_address_i           (csr_addr),
-        .csr_read_enable_o       (csr_read_enable),
-        .csr_data_read_i         (csr_data_read),
-        .csr_write_enable_o      (csr_write_enable),
-        .csr_operation_o         (csr_operation),
-        .csr_data_o              (csr_data_to_write),
-        .vtype_o                 (vtype),
-        .vlen_o                  (vlen),
-        .bp_taken_i              (bp_taken_exec),
-        .ctx_switch_o            (ctx_switch),
-        .jump_rollback_o         (jump_rollback),
-        .ctx_switch_target_o     (ctx_switch_target),
-        .jump_imm_target_i       (jump_imm_target_exec),
-        .reservation_data_i      (reservation_data),
-        .jump_target_o           (jump_target),
-        .compressed_i            (instruction_compressed_execute),
-        .pc_i                    (pc_execute),
-        .interrupt_pending_i     (interrupt_pending),
-        .mtvec_i                 (mtvec),
-        .mepc_i                  (mepc),
-        .pc_irq_o                (pc_irq),
-        .pc_exc_o                (pc_exc),
-        .jump_o                  (jump),
-        .should_jump_o           (should_jump),
-        .interrupt_ack_o         (interrupt_ack_o),
-        .machine_return_o        (MACHINE_RETURN),
-        .raise_exception_o       (RAISE_EXCEPTION),
-        .exception_code_o        (Exception_Code)
+        .vector_operation_i      (vector_operation_execute     ),
+
+        .exc_load_access_fault_i (load_access_fault            ),
+        .reservation_data_i      (reservation_data             ),
+
+        .privilege_i             (privilege                    ),
+        .interrupt_pending_i     (interrupt_pending            ),
+        .interrupt_ack_o         (interrupt_ack_o              ),
+        .machine_return_o        (MACHINE_RETURN               ),
+        .raise_exception_o       (RAISE_EXCEPTION              ),
+        .csr_read_enable_o       (csr_read_enable              ),
+        .csr_write_enable_o      (csr_write_enable             ),
+        .csr_operation_o         (csr_operation                ),
+        .exception_code_o        (Exception_Code               ),
+        .csr_data_read_i         (csr_data_read                ),
+        .csr_data_o              (csr_data_to_write            ),
+        .mtvec_i                 (mtvec                        ),
+        .mepc_i                  (mepc                         ),
+        .vtype_o                 (vtype                        ),
+        .vlen_o                  (vlen                         ),
+        .pc_irq_o                (pc_irq                       ),
+        .pc_exc_o                (pc_exc                       ),
+        
+        .mem_address_exec_o      (mem_address_exec             ),
+        .mem_address_o           (mem_address                  ),
+        .mem_enable_o            (mem_enable                   ),
+        .mem_write_enable_o      (mem_write_enable_o           ),
+        .mem_write_data_o        (mem_data_o                   ),
+        .mem_read_data_i         (mem_data_i                   ),
+        
+        .hold_o                  (hold                         ),
+        .write_enable_fwd_o      (write_enable_exec            ),
+        .jump_rollback_o         (jump_rollback                ),
+        .ctx_switch_o            (ctx_switch                   ),
+        .jump_o                  (jump                         ),
+        .should_jump_o           (should_jump                  ),
+        .ctx_switch_target_o     (ctx_switch_target            ),
+        .jump_target_o           (jump_target                  ),
+        .result_fwd_o            (result_exec                  ),
+
+        .ctrl_o                  (ctrl_mem_access              ),
+        .rd_o                    (rd_mem_access                ),
+        .result_o                (result_mem_access            ) 
     );
 
 /////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 /////////////////////////////////////////////////////////// MEMORY ACCESS ///////////////////////////////////////////////////////////////////////////
 /////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 
-    always_ff @(posedge clk or negedge reset_n) begin
-        if (!reset_n) begin
-            instruction_operation_retire <= NOP;
-            result_retire        <= '0;
-            rd_retire            <= '0;
-        end
-        else if (!stall) begin
-            instruction_operation_retire <= instruction_operation_mem_access;
-            result_retire                <= result_mem_access;
-            rd_retire                    <= rd_mem_access;
-        end
-    end
+    logic [31:0] result_retire;
 
-    always_ff @(posedge clk or negedge reset_n) begin
-        if (!reset_n)
-            regbank_write_enable <= '0;
-        else
-            regbank_write_enable <= (
-                write_enable_mem_access 
-                && !load_access_fault /* Disable write on load mmu exception     */
-                && !stall             /* Disable writing immediately after stall */
-            ); 
-    end
+    mem_access mem_access1 (
+        .clk                    (clk              ),
+        .reset_n                (reset_n          ),
+        .stall                  (stall            ),
 
-    if (XOSVMEnable == 1'b1) begin : gen_d_mmu_on
+        .ctrl_i                 (ctrl_mem_access  ),
+        .rd_i                   (rd_mem_access    ),
+        .result_i               (result_mem_access),
+
+        .load_access_fault_i    (load_access_fault),
+        
+        .ctrl_o                 (ctrl_retire      ),
+        .result_o               (result_retire    ),
+        .rd_o                   (rd_retire        )
+    );
+
+    /* Unused without MMU */
+    /* verilator lint_off UNUSEDSIGNAL */
+    logic     [31:0] mvmdo, mvmds, mvmdm;
+    /* verilator lint_on UNUSEDSIGNAL */
+
+    if (XOSVMEnable) begin : gen_d_mmu_on
         logic mmu_en_r;
+        logic mmu_data_fault;
+
         always_ff @(posedge clk or negedge reset_n) begin
-            if (!reset_n) begin
+            if (!reset_n)
                 mmu_en_r <= 1'b0;
-            end
-            else if (!stall) begin
+            else if (!stall)
                 mmu_en_r <= mmu_en;
-            end
         end
 
         mmu d_mmu (
-            .en_i           (mmu_en_r                  ),
-            .mask_i         (mvmdm                     ),
-            .offset_i       (mvmdo                     ),
-            .size_i         (mvmds                     ),
-            .address_i      ({mem_address[31:2], 2'b00}),
-            .exception_o    (mmu_data_fault            ),
-            .address_o      (mem_address_o             )
+            .en_i       (mmu_en_r                       ),
+            .mask_i     (mvmdm                          ),
+            .offset_i   (mvmdo                          ),
+            .size_i     (mvmds                          ),
+            .address_i  ({mem_address[31:2], 2'b00}     ),
+            .exception_o(mmu_data_fault                 ),
+            .address_o  (mem_address_o                  )
         );
-        assign load_access_fault = mem_enable && mmu_data_fault;
+
+        assign load_access_fault    = mem_enable && mmu_data_fault;
+        assign dmem_operation_enable_o = mem_enable && !mmu_data_fault;
     end
     else begin : gen_d_mmu_off
-        assign load_access_fault = 1'b0;
-        assign mmu_data_fault    = 1'b0;
-        assign mem_address_o     = {mem_address[31:2], 2'b00};
+        assign load_access_fault       = 1'b0;
+        assign mem_address_o           = {mem_address[31:2], 2'b00};
+        assign dmem_operation_enable_o = mem_enable;
     end
-
-    assign dmem_operation_enable_o = mem_enable && !mmu_data_fault;
 
 /////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 /////////////////////////////////////////////////////////// RETIRE //////////////////////////////////////////////////////////////////////////////////
@@ -523,14 +459,17 @@ module RS5
     retire #(
         .AMOEXT      (AMOEXT)
     ) retire1 (
-        .clk                    (clk),
-        .reset_n                (reset_n),
-        .regbank_we_i           (regbank_write_enable),
-        .instruction_operation_i(instruction_operation_retire),
-        .result_i               (result_retire),
-        .mem_data_i             (mem_data_i[31:0]),
-        .reservation_data_o     (reservation_data),
-        .regbank_data_o         (regbank_data_writeback)
+        .clk               (clk                   ),
+        .reset_n           (reset_n               ),
+
+        .ctrl_i            (ctrl_retire           ),
+        .result_i          (result_retire         ),
+
+        .mem_data_i        (mem_data_i[31:0]      ),
+
+        .regbank_data_o    (regbank_data_writeback),
+
+        .reservation_data_o(reservation_data      )
     );
 
 /////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
@@ -558,11 +497,11 @@ module RS5
         .operation_i                (csr_operation),
         .address_i                  (CSRs'(csr_addr)),
         .data_i                     (csr_data_to_write),
-        .killed                     (killed),
+        .killed                     (ctrl_execute.killed),
         .data_o                     (csr_data_read),
         .instruction_operation_i    (instruction_operation_execute),
         .vector_operation_i         (vector_operation_execute),
-        .hazard                     (hazard),
+        .hazard                     (ctrl_execute.hazard),
         .stall                      (stall),
         .hold                       (hold),
         .vtype_i                    (vtype),
@@ -576,8 +515,8 @@ module RS5
         .pc_irq_i                   (pc_irq),
         .pc_exc_i                   (pc_exc),
         .instruction_i              (instruction_execute),
-        .instruction_compressed_i   (instruction_compressed_execute),
-        .jump_misaligned_i          (jump_misaligned),
+        .instruction_compressed_i   (ctrl_execute.compressed),
+        .jump_misaligned_i          (decode_ctrl.jump_misaligned),
         .jump_target_i              (jump_target),
         .mtime_i                    (mtime_i),
         .tip_i                      (tip_i),

--- a/rtl/RS5.sv
+++ b/rtl/RS5.sv
@@ -349,7 +349,6 @@ module RS5
         .second_operand_i        (second_operand_execute       ),
         .jump_imm_target_i       (jump_imm_target_exec         ),
         .instruction_i           (instruction_execute          ),
-        .instruction_operation_i (instruction_operation_execute),
         .vector_operation_i      (vector_operation_execute     ),
 
         .exc_load_access_fault_i (load_access_fault            ),

--- a/rtl/RS5.sv
+++ b/rtl/RS5.sv
@@ -185,8 +185,6 @@ module RS5
     logic         [11:0] csr_addr;
     logic         [31:0] pc_execute, rs1_data_execute, rs2_data_execute;
     logic         [31:0] second_operand_execute, instruction_execute, jump_imm_target_exec;
-    iType_e              instruction_operation_execute;
-    iTypeVector_e        vector_operation_execute;
 
 
     assign enable_decode = !(stall || hold);
@@ -245,9 +243,7 @@ module RS5
         .rs2_data_o                 (rs2_data_execute             ),
         .second_operand_o           (second_operand_execute       ),
         .instruction_o              (instruction_execute          ),
-        .jump_imm_target_o          (jump_imm_target_exec         ),
-        .instruction_operation_o    (instruction_operation_execute),
-        .vector_operation_o         (vector_operation_execute     )
+        .jump_imm_target_o          (jump_imm_target_exec         )
     );
 
 /////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
@@ -349,7 +345,6 @@ module RS5
         .second_operand_i        (second_operand_execute       ),
         .jump_imm_target_i       (jump_imm_target_exec         ),
         .instruction_i           (instruction_execute          ),
-        .vector_operation_i      (vector_operation_execute     ),
 
         .exc_load_access_fault_i (load_access_fault            ),
         .reservation_data_i      (reservation_data             ),
@@ -496,11 +491,8 @@ module RS5
         .operation_i                (csr_operation),
         .address_i                  (CSRs'(csr_addr)),
         .data_i                     (csr_data_to_write),
-        .killed                     (ctrl_execute.killed),
         .data_o                     (csr_data_read),
-        .instruction_operation_i    (instruction_operation_execute),
-        .vector_operation_i         (vector_operation_execute),
-        .hazard                     (ctrl_execute.hazard),
+        .ctrl_i                     (ctrl_execute),
         .stall                      (stall),
         .hold                       (hold),
         .vtype_i                    (vtype),
@@ -514,7 +506,6 @@ module RS5
         .pc_irq_i                   (pc_irq),
         .pc_exc_i                   (pc_exc),
         .instruction_i              (instruction_execute),
-        .instruction_compressed_i   (ctrl_execute.compressed),
         .jump_misaligned_i          (decode_ctrl.jump_misaligned),
         .jump_target_i              (jump_target),
         .mtime_i                    (mtime_i),

--- a/rtl/RS5_pkg.sv
+++ b/rtl/RS5_pkg.sv
@@ -149,6 +149,121 @@ package RS5_pkg;
         NONE, WRITE, SET, CLEAR
     } csrOperation_e;
 
+    typedef enum  logic[9:0] {
+        AMONOP  = 10'b0000000001,
+        AMOSWAP = 10'b0000000010,
+        AMOADD  = 10'b0000000100,
+        AMOXOR  = 10'b0000001000,
+        AMOAND  = 10'b0000010000,
+        AMOOR   = 10'b0000100000,
+        AMOMIN  = 10'b0001000000,
+        AMOMAX  = 10'b0010000000,
+        AMOMINU = 10'b0100000000,
+        AMOMAXU = 10'b1000000000
+    } iTypeAtomic_e;
+
+    typedef struct packed {
+        // AMO operation select (one-hot, AMONOP when unused)
+        iTypeAtomic_e amo_op;
+        // Pipeline status
+        logic        hazard;
+        logic        killed;
+        logic        compressed;
+        logic        bp_taken;
+        logic        exc_ilegal_inst;
+        logic        exc_inst_access_fault;
+        // Result select
+        logic        is_csr;
+        logic        is_jal_jalr;
+        logic        is_lui;
+        logic        is_auipc;
+        logic        is_slt;
+        logic        is_sltu;
+        logic        is_xor;
+        logic        is_or;
+        logic        is_and;
+        logic        is_sll;
+        logic        is_srl;
+        logic        is_sra;
+        logic        is_mul;
+        logic        is_div;
+        logic        is_rem;
+        logic        is_aes;
+        logic        is_vector;
+        logic        is_zicond;
+        logic        is_zbkb;
+        logic        is_sc;
+        // Memory
+        logic        is_load;
+        logic        is_store;
+        logic        is_amo;
+        logic        is_lr;
+        // Branch/jump control
+        logic        is_beq;
+        logic        is_bne;
+        logic        is_blt;
+        logic        is_bltu;
+        logic        is_bge;
+        logic        is_bgeu;
+        logic        is_jalr;
+        // Write-back suppress
+        logic        rd_we;
+        // Opcode-derived exception/system flags
+        logic        is_ecall;
+        logic        is_ebreak;
+        logic        is_mret;
+        logic        is_sret;
+        logic        is_wfi;
+        // Memory width/sign for load/store
+        logic        is_byte;
+        logic        is_half;
+        logic        is_unsigned;
+        // Sub-op selects
+        logic        is_sub;
+        logic        is_amo_w;
+        // Mul sub-op
+        logic        mul_low;
+        logic [1:0]  mul_signed_mode;
+        // AES sub-op
+        logic        aes_is_mix;
+        // Zicond sub-op
+        logic        zicond_is_eqz;
+        // Div sub-op
+        logic        div_signed;
+        // CSR operation
+        csrOperation_e csr_op;
+        logic        csr_rd_uses_rs1;
+        logic        csr_wr_uses_rs1;
+        // Zbkb sub-op
+        logic        zbkb_is_ror;
+        logic        zbkb_is_rol;
+        logic        zbkb_is_packh;
+        logic        zbkb_is_orn;
+        logic        zbkb_is_andn;
+        logic        zbkb_is_rev8;
+        logic        zbkb_is_brev8;
+        logic        zbkb_is_zip;
+        logic        zbkb_is_unzip;
+        logic        zbkb_is_xnor;
+    } exec_ctrl_t;
+
+    typedef struct packed {
+        logic        valid;
+        logic        compressed;
+        logic        jumping;
+        logic        jump_misaligned;
+    } decode_ctrl_t;
+
+    typedef struct packed {
+        logic        rd_we;
+        logic        is_load;
+        logic        is_lr;
+        logic        is_sc;
+        logic        is_byte;
+        logic        is_half;
+        logic        is_unsigned;
+    } wb_ctrl_t;
+
     typedef enum logic {
         M_IDLE, M_CALC
     } mult_states_e;
@@ -310,18 +425,6 @@ package RS5_pkg;
         VSLIDE1DOWN
     } iTypeVector_e;
 
-    typedef enum  logic[9:0] {
-        AMONOP  = 10'b0000000001,
-        AMOSWAP = 10'b0000000010,
-        AMOADD  = 10'b0000000100,
-        AMOXOR  = 10'b0000001000,
-        AMOAND  = 10'b0000010000,
-        AMOOR   = 10'b0000100000,
-        AMOMIN  = 10'b0001000000,
-        AMOMAX  = 10'b0010000000,
-        AMOMINU = 10'b0100000000,
-        AMOMAXU = 10'b1000000000
-    } iTypeAtomic_e;
 
     typedef enum  logic[2:0] {
         OPIVV = 3'b000,

--- a/rtl/RS5_pkg.sv
+++ b/rtl/RS5_pkg.sv
@@ -162,9 +162,116 @@ package RS5_pkg;
         AMOMAXU = 10'b1000000000
     } iTypeAtomic_e;
 
+    typedef enum logic[10:0] {
+        SHA2NOP   = 11'b00000000001,
+        SHA2SIG0  = 11'b00000000010,
+        SHA2SIG1  = 11'b00000000100,
+        SHA2SUM0  = 11'b00000001000,
+        SHA2SUM1  = 11'b00000010000,
+        SHA2SIG0H = 11'b00000100000,
+        SHA2SIG0L = 11'b00001000000,
+        SHA2SIG1H = 11'b00010000000,
+        SHA2SIG1L = 11'b00100000000,
+        SHA2SUM0R = 11'b01000000000,
+        SHA2SUM1R = 11'b10000000000
+    } iTypeSha2_e;
+
+    typedef enum logic[6:0] {
+        KYBNOP      = 7'b0000001,
+        KYBADD      = 7'b0000010,
+        KYBSUB      = 7'b0000100,
+        KYBCBD2     = 7'b0001000,
+        KYBCBD3     = 7'b0010000,
+        KYBMUL      = 7'b0100000,
+        KYBCOMPRESS = 7'b1000000
+    } iTypeKyber_e;
+
+    typedef enum logic[11:0] {
+        ZBKBNOP   = 12'b000000000001,
+        ZBKBROR   = 12'b000000000010,
+        ZBKBROL   = 12'b000000000100,
+        ZBKBPACK  = 12'b000000001000,
+        ZBKBPACKH = 12'b000000010000,
+        ZBKBXNOR  = 12'b000000100000,
+        ZBKBORN   = 12'b000001000000,
+        ZBKBANDN  = 12'b000010000000,
+        ZBKBZIP   = 12'b000100000000,
+        ZBKBUNZIP = 12'b001000000000,
+        ZBKBBREV8 = 12'b010000000000,
+        ZBKBREV8  = 12'b100000000000
+    } iTypeZbkb_e;
+
+    typedef enum logic [5:0] {
+        VNOP,
+        VSETVL,
+        VSETVLI,
+        VSETIVLI,
+        VADD,
+        VSUB,
+        VRSUB,
+        VAND,
+        VOR,
+        VXOR,
+        VSLL,
+        VSRL,
+        VSRA,
+        VMSEQ,
+        VMSNE,
+        VMSLTU,
+        VMSLT,
+        VMSLEU,
+        VMSLE,
+        VMSGTU,
+        VMSGT,
+        VMINU,
+        VMIN,
+        VMAXU,
+        VMAX,
+        VMUL,
+        VMULH,
+        VMULHU,
+        VMULHSU,
+        VWMUL,
+        VWMULU,
+        VWMULSU,
+        VDIVU,
+        VDIV,
+        VREMU,
+        VREM,
+        VMACC,
+        VNMSAC,
+        VMADD,
+        VNMSUB,
+        VREDSUM,
+        VREDMAXU,
+        VREDMAX,
+        VREDMINU,
+        VREDMIN,
+        VREDAND,
+        VREDOR,
+        VREDXOR,
+        VMV,
+        VMVR,
+        VMVSX,
+        VMVXS,
+        VMERGE,
+        VSLIDE1UP,
+        VSLIDE1DOWN,
+        VLD,            // Vector load  (was iType_e VLOAD)
+        VST             // Vector store (was iType_e VSTORE)
+    } iTypeVector_e;
+
     typedef struct packed {
         // AMO operation select (one-hot, AMONOP when unused)
         iTypeAtomic_e amo_op;
+        // SHA2 operation select (one-hot, SHA2NOP when unused)
+        iTypeSha2_e  sha2_op;
+        // Kyber operation select (one-hot, KYBNOP when unused)
+        iTypeKyber_e kyber_op;
+        // Zbkb operation select (one-hot, ZBKBNOP when unused)
+        iTypeZbkb_e  zbkb_op;
+        // Vector operation select (VNOP when unused)
+        iTypeVector_e vector_op;
         // Pipeline status
         logic        hazard;
         logic        killed;
@@ -173,6 +280,8 @@ package RS5_pkg;
         logic        exc_ilegal_inst;
         logic        exc_inst_access_fault;
         // Result select
+        logic        is_nop;
+        logic        is_add;
         logic        is_csr;
         logic        is_jal_jalr;
         logic        is_lui;
@@ -190,8 +299,12 @@ package RS5_pkg;
         logic        is_rem;
         logic        is_aes;
         logic        is_vector;
+        // Vector loads/stores (subset of is_vector)
+        logic        is_vector_mem;
         logic        is_zicond;
+        logic        is_sha2;
         logic        is_zbkb;
+        logic        is_kyber;
         logic        is_sc;
         // Memory
         logic        is_load;
@@ -234,17 +347,6 @@ package RS5_pkg;
         csrOperation_e csr_op;
         logic        csr_rd_uses_rs1;
         logic        csr_wr_uses_rs1;
-        // Zbkb sub-op
-        logic        zbkb_is_ror;
-        logic        zbkb_is_rol;
-        logic        zbkb_is_packh;
-        logic        zbkb_is_orn;
-        logic        zbkb_is_andn;
-        logic        zbkb_is_rev8;
-        logic        zbkb_is_brev8;
-        logic        zbkb_is_zip;
-        logic        zbkb_is_unzip;
-        logic        zbkb_is_xnor;
     } exec_ctrl_t;
 
     typedef struct packed {
@@ -366,66 +468,6 @@ package RS5_pkg;
         LMUL_1_4  = 3'b110,
         LMUL_1_2  = 3'b111
     } vlmul_e;
-
-    typedef enum {
-        VNOP,
-        VSETVL,
-        VSETVLI,
-        VSETIVLI,
-        VADD,
-        VSUB,
-        VRSUB,
-        VAND,
-        VOR,
-        VXOR,
-        VSLL,
-        VSRL,
-        VSRA,
-        VMSEQ,
-        VMSNE,
-        VMSLTU,
-        VMSLT,
-        VMSLEU,
-        VMSLE,
-        VMSGTU,
-        VMSGT,
-        VMINU,
-        VMIN,
-        VMAXU,
-        VMAX,
-        VMUL,
-        VMULH,
-        VMULHU,
-        VMULHSU,
-        VWMUL,
-        VWMULU,
-        VWMULSU,
-        VDIVU,
-        VDIV,
-        VREMU,
-        VREM,
-        VMACC,
-        VNMSAC,
-        VMADD,
-        VNMSUB,
-        VREDSUM,
-        VREDMAXU,
-        VREDMAX,
-        VREDMINU,
-        VREDMIN,
-        VREDAND,
-        VREDOR,
-        VREDXOR,
-        VMV,
-        VMVR,
-        VMVSX,
-        VMVXS,
-        VMERGE,
-        VSLIDE1UP,
-        VSLIDE1DOWN,
-        VLD,            // Vector load  (was iType_e VLOAD)
-        VST             // Vector store (was iType_e VSTORE)
-    } iTypeVector_e;
 
 
     typedef enum  logic[2:0] {

--- a/rtl/RS5_pkg.sv
+++ b/rtl/RS5_pkg.sv
@@ -422,7 +422,9 @@ package RS5_pkg;
         VMVXS,
         VMERGE,
         VSLIDE1UP,
-        VSLIDE1DOWN
+        VSLIDE1DOWN,
+        VLD,            // Vector load  (was iType_e VLOAD)
+        VST             // Vector store (was iType_e VSTORE)
     } iTypeVector_e;
 
 

--- a/rtl/decode.sv
+++ b/rtl/decode.sv
@@ -68,20 +68,17 @@ module decode
     input   logic [31:0]    rs2_data_read_i,
 
     /* Combinational forwarding */
+    input   logic           regbank_we_i,
+    input   logic [ 4:0]    rd_retire_i,
+    input   logic [31:0]    writeback_i,
     /* Not used without forwarding */
     /* verilator lint_off UNUSEDSIGNAL */
     input   logic           execute_we_i,
-    /* verilator lint_on UNUSEDSIGNAL */
     input   logic           mem_access_we_i,
-    input   logic           regbank_we_i,
     input   logic [ 4:0]    rd_mem_access_i,
-    input   logic [ 4:0]    rd_retire_i,
-    /* Not used without forwarding */
-    /* verilator lint_off UNUSEDSIGNAL */
     input   logic [31:0]    result_i,
-    /* verilator lint_on UNUSEDSIGNAL */
     input   logic [31:0]    mem_access_result_i,
-    input   logic [31:0]    writeback_i,  
+    /* verilator lint_on UNUSEDSIGNAL */  
     
     /* Combinational outputs to fetch */
     output  logic           dec_hazard_o,

--- a/rtl/decode.sv
+++ b/rtl/decode.sv
@@ -98,9 +98,7 @@ module decode
     output  logic [31:0]    rs2_data_o,
     output  logic [31:0]    second_operand_o,
     output  logic [31:0]    instruction_o,
-    output  logic [31:0]    jump_imm_target_o,
-    output  iType_e         instruction_operation_o,
-    output  iTypeVector_e   vector_operation_o
+    output  logic [31:0]    jump_imm_target_o
 );
 
 //////////////////////////////////////////////////////////////////////////////
@@ -350,8 +348,9 @@ module decode
 //  Decode Vector Instruction
 //////////////////////////////////////////////////////////////////////////////
 
+    iTypeVector_e vector_operation;
+
     if (VEnable) begin : v_enable_decode_gen_on
-        iTypeVector_e vector_operation;
         iTypeVector_e decode_vector_opcfg;
         iTypeVector_e decode_vector_opi;
         iTypeVector_e decode_vector_opm;
@@ -452,24 +451,9 @@ module decode
             end
         end
 
-        always_ff @(posedge clk)
-            if (instruction_operation_o == VECTOR && vector_operation_o == VNOP)
-                $display("%0t - INVALID VECTOR INST!!! - %h", $time, instruction_o);
-
-        always_ff @(posedge clk or negedge reset_n) begin
-            if (!reset_n) begin
-                vector_operation_o <= VNOP;
-            end
-            else if (enable) begin
-                if (hazard || killed)
-                    vector_operation_o <= VNOP;
-                else
-                    vector_operation_o <= vector_operation;
-            end
-        end
     end
-    else begin : v_enable_decode_gen_on
-        assign vector_operation_o = VNOP;
+    else begin : v_enable_decode_gen_off
+        assign vector_operation = VNOP;
     end
 
 //////////////////////////////////////////////////////////////////////////////
@@ -794,22 +778,6 @@ module decode
             instruction_o <= (!COMPRESSED && ctrl_i.compressed) ? {16'h0000, instruction_i[15:0]} : instruction_i;
     end
 
-
-    always_ff @(posedge clk or negedge reset_n) begin
-        if (!reset_n) begin
-            instruction_operation_o <= NOP;
-        end
-        else if (sys_reset) begin
-            instruction_operation_o <= NOP;
-        end
-        else if (enable) begin
-            if (hazard || killed)
-                instruction_operation_o <= NOP;
-            else
-                instruction_operation_o <= instruction_operation;
-        end
-    end
-
 //////////////////////////////////////////////////////////////////////////////
 // Control struct combinational decode
 //////////////////////////////////////////////////////////////////////////////
@@ -818,6 +786,9 @@ module decode
 
     always_comb begin
         ctrl = '0;
+
+        ctrl.is_nop          = instruction_operation == NOP;
+        ctrl.is_add          = instruction_operation == ADD;
 
         // Result select
         ctrl.is_csr          = instruction_operation inside {CSRRW, CSRRS, CSRRC, CSRRWI, CSRRSI, CSRRCI};
@@ -844,11 +815,16 @@ module decode
         ctrl.is_aes          = ZKNEEnable   && instruction_operation inside {AES32ESI, AES32ESMI};
         ctrl.aes_is_mix      = ZKNEEnable   && instruction_operation == AES32ESMI;
         ctrl.is_vector       = VEnable      && instruction_operation inside {VECTOR, VLOAD, VSTORE};
+        ctrl.is_vector_mem   = VEnable      && instruction_operation inside {VLOAD, VSTORE};
         ctrl.is_zicond       = ZICONDEnable && instruction_operation inside {CZERO_EQZ, CZERO_NEZ};
         ctrl.zicond_is_eqz   = ZICONDEnable && instruction_operation == CZERO_EQZ;
-        ctrl.is_zbkb         = ZBKBEnable   && instruction_operation inside {ALU_ROL, ALU_ROR, ALU_PACK, ALU_PACKH,
-                                                                             ALU_XNOR, ALU_ORN, ALU_ANDN,
-                                                                             ALU_ZIP, ALU_UNZIP, ALU_BREV8, ALU_REV8};
+        ctrl.is_sha2         = ZKNHEnable   && instruction_operation inside {SIG0, SIG1, SUM0, SUM1, SIG0H, SIG0L,
+                                                                             SIG1H, SIG1L, SUM0R, SUM1R};
+        ctrl.is_zbkb         = ZBKBEnable   && instruction_operation inside {ALU_ROR, ALU_ROL, ALU_PACK, ALU_PACKH,
+                                                                             ALU_XNOR, ALU_ORN, ALU_ANDN, ALU_ZIP,
+                                                                             ALU_UNZIP, ALU_BREV8, ALU_REV8};
+        ctrl.is_kyber        = XKYBEREnable && instruction_operation inside {KYBER_ADD, KYBER_SUB, KYBER_CBD2,
+                                                                             KYBER_CBD3, KYBER_MUL, KYBER_COMPRESS};
         ctrl.is_sc           = (AMOEXT inside {AMO_ZALRSC, AMO_A}) && instruction_operation == SC_W;
 
         // Memory
@@ -893,19 +869,50 @@ module decode
         ctrl.csr_rd_uses_rs1 = instruction_operation inside {CSRRW, CSRRS, CSRRC};
         ctrl.csr_wr_uses_rs1 = instruction_operation inside {CSRRS, CSRRC, CSRRSI, CSRRCI};
 
-        // Zbkb sub-ops
-        ctrl.zbkb_is_ror     = ZBKBEnable && instruction_operation == ALU_ROR;
-        ctrl.zbkb_is_rol     = ZBKBEnable && instruction_operation == ALU_ROL;
-        ctrl.zbkb_is_packh   = ZBKBEnable && instruction_operation == ALU_PACKH;
-        ctrl.zbkb_is_orn     = ZBKBEnable && instruction_operation == ALU_ORN;
-        ctrl.zbkb_is_andn    = ZBKBEnable && instruction_operation == ALU_ANDN;
-        ctrl.zbkb_is_rev8    = ZBKBEnable && instruction_operation == ALU_REV8;
-        ctrl.zbkb_is_brev8   = ZBKBEnable && instruction_operation == ALU_BREV8;
-        ctrl.zbkb_is_zip     = ZBKBEnable && instruction_operation == ALU_ZIP;
-        ctrl.zbkb_is_unzip   = ZBKBEnable && instruction_operation == ALU_UNZIP;
-        ctrl.zbkb_is_xnor    = ZBKBEnable && instruction_operation == ALU_XNOR;
+        // Zbkb sub-op
+        unique case (instruction_operation)
+            ALU_ROR:   ctrl.zbkb_op = ZBKBROR;
+            ALU_ROL:   ctrl.zbkb_op = ZBKBROL;
+            ALU_PACK:  ctrl.zbkb_op = ZBKBPACK;
+            ALU_PACKH: ctrl.zbkb_op = ZBKBPACKH;
+            ALU_XNOR:  ctrl.zbkb_op = ZBKBXNOR;
+            ALU_ORN:   ctrl.zbkb_op = ZBKBORN;
+            ALU_ANDN:  ctrl.zbkb_op = ZBKBANDN;
+            ALU_ZIP:   ctrl.zbkb_op = ZBKBZIP;
+            ALU_UNZIP: ctrl.zbkb_op = ZBKBUNZIP;
+            ALU_BREV8: ctrl.zbkb_op = ZBKBBREV8;
+            ALU_REV8:  ctrl.zbkb_op = ZBKBREV8;
+            default:   ctrl.zbkb_op = ZBKBNOP;
+        endcase
 
         ctrl.amo_op          = amo_op_next;
+        ctrl.vector_op       = vector_operation;
+
+        // SHA2 sub-op
+        unique case (instruction_operation)
+            SIG0:    ctrl.sha2_op = SHA2SIG0;
+            SIG1:    ctrl.sha2_op = SHA2SIG1;
+            SUM0:    ctrl.sha2_op = SHA2SUM0;
+            SUM1:    ctrl.sha2_op = SHA2SUM1;
+            SIG0H:   ctrl.sha2_op = SHA2SIG0H;
+            SIG0L:   ctrl.sha2_op = SHA2SIG0L;
+            SIG1H:   ctrl.sha2_op = SHA2SIG1H;
+            SIG1L:   ctrl.sha2_op = SHA2SIG1L;
+            SUM0R:   ctrl.sha2_op = SHA2SUM0R;
+            SUM1R:   ctrl.sha2_op = SHA2SUM1R;
+            default: ctrl.sha2_op = SHA2NOP;
+        endcase
+
+        // Kyber sub-op
+        unique case (instruction_operation)
+            KYBER_ADD:      ctrl.kyber_op = KYBADD;
+            KYBER_SUB:      ctrl.kyber_op = KYBSUB;
+            KYBER_CBD2:     ctrl.kyber_op = KYBCBD2;
+            KYBER_CBD3:     ctrl.kyber_op = KYBCBD3;
+            KYBER_MUL:      ctrl.kyber_op = KYBMUL;
+            KYBER_COMPRESS: ctrl.kyber_op = KYBCOMPRESS;
+            default:        ctrl.kyber_op = KYBNOP;
+        endcase
 
         // Pipeline status fields
         ctrl.compressed            = ctrl_i.compressed;
@@ -924,8 +931,14 @@ module decode
         else if (enable) begin
             if (hazard || killed) begin
                 ctrl_o        <= '0;
+                /* A bubble behaves as a NOP (e.g. for instruction counters) */
+                ctrl_o.is_nop <= 1'b1;
                 ctrl_o.hazard <= hazard;
                 ctrl_o.killed <= killed;
+                /* An excepting instruction is killed (turned into a NOP) */
+                /* but its exception must still reach execute             */
+                ctrl_o.exc_ilegal_inst       <= invalid_inst;
+                ctrl_o.exc_inst_access_fault <= exc_inst_access_fault;
             end
             else
                 ctrl_o <= ctrl;

--- a/rtl/decode.sv
+++ b/rtl/decode.sv
@@ -45,63 +45,62 @@ module decode
     input   logic           reset_n,
     input   logic           enable,
     input   logic           sys_reset,
-    input   logic           valid_i,
 
-    input   logic [31:0]    instruction_i,
+    /* Registered inputs from fetch */
+    input   decode_ctrl_t   ctrl_i,
     input   logic [31:0]    pc_i,
-    input   logic [31:0]    rs1_data_read_i,
-    input   logic [31:0]    rs2_data_read_i,
-    input   logic [31:0]    mem_access_result_i,
-    input   logic [31:0]    writeback_i,
-    input   logic [ 4:0]    rd_mem_access_i,
-    input   logic [ 4:0]    rd_retire_i,
-    input   logic           mem_access_we_i,
-    input   logic           regbank_we_i,
-    input   logic           compressed_i,
+    input   logic [31:0]    instruction_i,
+
+    /* Combinational inputs from execute */
     input   logic           should_jump_i,
-
-    /* Not used without forwarding */
-    /* verilator lint_off UNUSEDSIGNAL */
-    input   logic [31:0]    result_i,
-    input   logic           execute_we_i,
-    /* verilator lint_on UNUSEDSIGNAL */
-
-    output  logic  [4:0]    rs1_o,
-    output  logic  [4:0]    rs2_o,
-    output  logic  [4:0]    rd_o,
-    output  logic  [4:0]    instr_rs1_o,
-    output  logic [11:0]    csr_address_o,
-    output  logic [31:0]    rs1_data_o,
-    output  logic [31:0]    rs2_data_o,
-    output  logic [31:0]    second_operand_o,
-    output  logic [31:0]    pc_o,
-    output  logic [31:0]    instruction_o,
-    output  logic [31:0]    jump_imm_target_o,
-
-    output  logic           compressed_o,
-    output  iType_e         instruction_operation_o,
-    output  iTypeAtomic_e   atomic_operation_o,
-    output  iTypeVector_e   vector_operation_o,
-    output  logic           dec_hazard_o,
-    output  logic           hazard_o,
-    output  logic           killed_o,
-
     /* Not used without BP */
     /* verilator lint_off UNUSEDSIGNAL */
     input   logic           jump_rollback_i,
     /* verilator lint_on UNUSEDSIGNAL */
-    input   logic           jumping_i,
-    /* Not used without C */
+
+    /* Combinational inputs from mem_access */
+    input   logic           exc_inst_access_fault_i,
+
+    /* Combinational regbank access */
+    output  logic  [4:0]    rs1_o,
+    output  logic  [4:0]    rs2_o,
+    input   logic [31:0]    rs1_data_read_i,
+    input   logic [31:0]    rs2_data_read_i,
+
+    /* Combinational forwarding */
+    /* Not used without forwarding */
     /* verilator lint_off UNUSEDSIGNAL */
-    input   logic           jump_misaligned_i,
+    input   logic           execute_we_i,
+    /* verilator lint_on UNUSEDSIGNAL */
+    input   logic           mem_access_we_i,
+    input   logic           regbank_we_i,
+    input   logic [ 4:0]    rd_mem_access_i,
+    input   logic [ 4:0]    rd_retire_i,
+    /* Not used without forwarding */
     /* verilator lint_off UNUSEDSIGNAL */
+    input   logic [31:0]    result_i,
+    /* verilator lint_on UNUSEDSIGNAL */
+    input   logic [31:0]    mem_access_result_i,
+    input   logic [31:0]    writeback_i,  
+    
+    /* Combinational outputs to fetch */
+    output  logic           dec_hazard_o,
     output  logic           bp_take_o,
-    output  logic           bp_taken_o,
     output  logic [31:0]    bp_target_o,
 
-    input   logic           exc_inst_access_fault_i,
-    output  logic           exc_inst_access_fault_o,
-    output  logic           exc_ilegal_inst_o
+    /* Registered outputs to execute */
+    output  exec_ctrl_t     ctrl_o,
+    output  logic  [4:0]    rd_o,
+    output  logic  [4:0]    instr_rs1_o,
+    output  logic [11:0]    csr_address_o,
+    output  logic [31:0]    pc_o,
+    output  logic [31:0]    rs1_data_o,
+    output  logic [31:0]    rs2_data_o,
+    output  logic [31:0]    second_operand_o,
+    output  logic [31:0]    instruction_o,
+    output  logic [31:0]    jump_imm_target_o,
+    output  iType_e         instruction_operation_o,
+    output  iTypeVector_e   vector_operation_o
 );
 
 //////////////////////////////////////////////////////////////////////////////
@@ -166,7 +165,6 @@ module decode
         endcase
     end
 
-
     iType_e brev_op;
     always_comb begin
         unique case (instruction_i[26:20])
@@ -175,7 +173,6 @@ module decode
             default:     brev_op = INVALID;
         endcase
     end
-
 
     iType_e decode_op_imm;
     always_comb begin
@@ -286,6 +283,7 @@ module decode
 
     logic         amo_invalid;
     iType_e       decode_atomic;
+    iTypeAtomic_e amo_op_next;
     if (AMOEXT != AMO_OFF) begin : gen_amo_on
         always_comb begin
             unique case (funct7[6:2])
@@ -313,23 +311,17 @@ module decode
             end
 
             assign amo_invalid = (instruction_operation == AMO_W) && (decode_amo == AMONOP);
-
-            always_ff @(posedge clk or negedge reset_n) begin
-                if (!reset_n)
-                    atomic_operation_o <= AMONOP;
-                else if (enable)
-                    atomic_operation_o <= decode_amo;
-            end
+            assign amo_op_next = decode_amo;
         end
         else begin : gen_zaamo_off
-            assign amo_invalid        = 1'b0;
-            assign atomic_operation_o = AMONOP;
+            assign amo_invalid = 1'b0;
+            assign amo_op_next = AMONOP;
         end
     end
     else begin : gen_amo_off
-        assign decode_atomic      = INVALID;
-        assign amo_invalid        = 1'b0;
-        assign atomic_operation_o = AMONOP;
+        assign decode_atomic = INVALID;
+        assign amo_invalid   = 1'b0;
+        assign amo_op_next   = AMONOP;
     end
 
     always_comb begin
@@ -358,9 +350,8 @@ module decode
 //  Decode Vector Instruction
 //////////////////////////////////////////////////////////////////////////////
 
-    iTypeVector_e vector_operation;
-
     if (VEnable) begin : v_enable_decode_gen_on
+        iTypeVector_e vector_operation;
         iTypeVector_e decode_vector_opcfg;
         iTypeVector_e decode_vector_opi;
         iTypeVector_e decode_vector_opm;
@@ -472,7 +463,6 @@ module decode
         end
     end
     else begin : v_enable_decode_gen_on
-        assign vector_operation = VNOP;
         assign vector_operation_o = VNOP;
     end
 
@@ -544,23 +534,13 @@ module decode
         assign bp_branch_taken = (opcode == 5'b11000 && imm_b[31]);
         assign bp_jump_taken   = (opcode == 5'b11011);
 
-        assign bp_take_o   = (bp_jump_taken || bp_branch_taken) && !jumping_i && !killed;
+        assign bp_take_o   = (bp_jump_taken || bp_branch_taken) && !ctrl_i.jumping && !killed;
 
-        assign jump_confirmed = should_jump_i || (jumping_i && !jump_rollback_i);
-        
-        always_ff @(posedge clk or negedge reset_n) begin
-            if (!reset_n)
-                bp_taken_o <= 1'b0;
-            else if (sys_reset)
-                bp_taken_o <= 1'b0;
-            else if (enable && !hazard)
-                bp_taken_o <= bp_take_o;
-        end
+        assign jump_confirmed = should_jump_i || (ctrl_i.jumping && !jump_rollback_i);
     end
     else begin : gen_bp_off
         assign bp_take_o   = 1'b0;
-        assign bp_taken_o  = 1'b0;
-        assign jump_confirmed = should_jump_i || jumping_i;
+        assign jump_confirmed = should_jump_i || ctrl_i.jumping;
     end
 
 //////////////////////////////////////////////////////////////////////////////
@@ -694,24 +674,11 @@ module decode
     assign hazard_rs2 = locked_rs2 && use_rs2;
 
     logic invalid;
-    assign invalid      = jump_confirmed || jump_misaligned_i || !valid_i;
+    assign invalid      = jump_confirmed || ctrl_i.jump_misaligned || !ctrl_i.valid;
     assign killed       = invalid || exception;
     assign hazard       = (hazard_mem || hazard_rs1 || hazard_rs2) && !killed;
     assign dec_hazard_o = hazard;
 
-    always_ff @(posedge clk or negedge reset_n) begin
-        if (!reset_n)
-            killed_o <= 1'b0;
-        else if (enable)
-            killed_o <= killed;
-    end
-
-    always_ff @(posedge clk or negedge reset_n) begin
-        if (!reset_n)
-            hazard_o <= 1'b0;
-        else if (enable)
-            hazard_o <= hazard;
-    end
 
 //////////////////////////////////////////////////////////////////////////////
 // Exception Detection
@@ -725,19 +692,6 @@ module decode
 
     assign exception = exc_inst_access_fault || invalid_inst;
 
-    always_ff @(posedge clk or negedge reset_n) begin
-        if (!reset_n)
-            exc_ilegal_inst_o <= 1'b0;
-        else if (enable)
-            exc_ilegal_inst_o <= invalid_inst;
-    end
-
-    always_ff @(posedge clk or negedge reset_n) begin
-        if (!reset_n)
-            exc_inst_access_fault_o <= 1'b0;
-        else if (enable)
-            exc_inst_access_fault_o <= exc_inst_access_fault;
-    end
 
 //////////////////////////////////////////////////////////////////////////////
 // Control of the operands based on format
@@ -831,15 +785,9 @@ module decode
         if (!reset_n)
             instruction_o <= '0;
         else if (enable)
-            instruction_o <= (!COMPRESSED && compressed_i) ? {16'h0000, instruction_i[15:0]} : instruction_i;
+            instruction_o <= (!COMPRESSED && ctrl_i.compressed) ? {16'h0000, instruction_i[15:0]} : instruction_i;
     end
 
-    always_ff @(posedge clk or negedge reset_n) begin
-        if (!reset_n)
-            compressed_o <= 1'b0;
-        else if (enable)
-            compressed_o <= compressed_i;
-    end
 
     always_ff @(posedge clk or negedge reset_n) begin
         if (!reset_n) begin
@@ -853,6 +801,128 @@ module decode
                 instruction_operation_o <= NOP;
             else
                 instruction_operation_o <= instruction_operation;
+        end
+    end
+
+//////////////////////////////////////////////////////////////////////////////
+// Control struct combinational decode
+//////////////////////////////////////////////////////////////////////////////
+
+    exec_ctrl_t ctrl;
+
+    always_comb begin
+        ctrl = '0;
+
+        // Result select
+        ctrl.is_csr          = instruction_operation inside {CSRRW, CSRRS, CSRRC, CSRRWI, CSRRSI, CSRRCI};
+        ctrl.is_jal_jalr     = instruction_operation inside {JAL, JALR};
+        ctrl.is_jalr         = instruction_operation == JALR;
+        ctrl.is_lui          = instruction_operation == LUI;
+        ctrl.is_auipc        = instruction_operation == AUIPC;
+        ctrl.is_slt          = instruction_operation == SLT;
+        ctrl.is_sltu         = instruction_operation == SLTU;
+        ctrl.is_xor          = instruction_operation == XOR;
+        ctrl.is_or           = instruction_operation == OR;
+        ctrl.is_and          = instruction_operation == AND;
+        ctrl.is_sll          = instruction_operation == SLL;
+        ctrl.is_srl          = instruction_operation == SRL;
+        ctrl.is_sra          = instruction_operation == SRA;
+        ctrl.is_sub          = instruction_operation == SUB;
+        ctrl.is_mul          = (MULEXT != MUL_OFF) && instruction_operation inside {MUL, MULH, MULHU, MULHSU};
+        ctrl.mul_low         = (MULEXT != MUL_OFF) && instruction_operation == MUL;
+        ctrl.mul_signed_mode = (MULEXT != MUL_OFF) && instruction_operation == MULH   ? 2'b11 :
+                               (MULEXT != MUL_OFF) && instruction_operation == MULHSU ? 2'b01 : 2'b00;
+        ctrl.is_div          = (MULEXT == MUL_M)   && instruction_operation inside {DIV, DIVU};
+        ctrl.is_rem          = (MULEXT == MUL_M)   && instruction_operation inside {REM, REMU};
+        ctrl.div_signed      = (MULEXT == MUL_M)   && instruction_operation inside {DIV, REM};
+        ctrl.is_aes          = ZKNEEnable   && instruction_operation inside {AES32ESI, AES32ESMI};
+        ctrl.aes_is_mix      = ZKNEEnable   && instruction_operation == AES32ESMI;
+        ctrl.is_vector       = VEnable      && instruction_operation inside {VECTOR, VLOAD, VSTORE};
+        ctrl.is_zicond       = ZICONDEnable && instruction_operation inside {CZERO_EQZ, CZERO_NEZ};
+        ctrl.zicond_is_eqz   = ZICONDEnable && instruction_operation == CZERO_EQZ;
+        ctrl.is_zbkb         = ZBKBEnable   && instruction_operation inside {ALU_ROL, ALU_ROR, ALU_PACK, ALU_PACKH,
+                                                                             ALU_XNOR, ALU_ORN, ALU_ANDN,
+                                                                             ALU_ZIP, ALU_UNZIP, ALU_BREV8, ALU_REV8};
+        ctrl.is_sc           = (AMOEXT inside {AMO_ZALRSC, AMO_A}) && instruction_operation == SC_W;
+
+        // Memory
+        ctrl.is_load         = instruction_operation inside {LB, LBU, LH, LHU, LW};
+        ctrl.is_store        = instruction_operation inside {SB, SH, SW};
+        ctrl.is_lr           = (AMOEXT inside {AMO_ZALRSC, AMO_A}) && instruction_operation == LR_W;
+        ctrl.is_amo          = (AMOEXT inside {AMO_ZAAMO,  AMO_A}) && instruction_operation == AMO_W;
+        ctrl.is_amo_w        = (AMOEXT != AMO_OFF)                 && instruction_operation inside {AMO_W, SC_W, LR_W};
+
+        // Memory width/sign
+        ctrl.is_byte         = instruction_operation inside {LB, LBU, SB};
+        ctrl.is_half         = instruction_operation inside {LH, LHU, SH};
+        ctrl.is_unsigned     = instruction_operation inside {LBU, LHU};
+
+        // Branch
+        ctrl.is_beq          = instruction_operation == BEQ;
+        ctrl.is_bne          = instruction_operation == BNE;
+        ctrl.is_blt          = instruction_operation == BLT;
+        ctrl.is_bltu         = instruction_operation == BLTU;
+        ctrl.is_bge          = instruction_operation == BGE;
+        ctrl.is_bgeu         = instruction_operation == BGEU;
+
+        // Write-back suppress (instructions that never write rd)
+        ctrl.rd_we           = !(instruction_operation inside {NOP, SB, SH, SW,
+                                                           BEQ, BNE, BLT, BLTU, BGE, BGEU});
+
+        // Opcode-derived system/exception flags
+        ctrl.is_ecall        = instruction_operation == ECALL;
+        ctrl.is_ebreak       = instruction_operation == EBREAK;
+        ctrl.is_mret         = instruction_operation == MRET;
+        ctrl.is_sret         = instruction_operation == SRET;
+        ctrl.is_wfi          = instruction_operation == WFI;
+
+        // CSR operation type
+        unique case (instruction_operation)
+            CSRRW, CSRRWI: ctrl.csr_op = WRITE;
+            CSRRS, CSRRSI: ctrl.csr_op = SET;
+            CSRRC, CSRRCI: ctrl.csr_op = CLEAR;
+            default:       ctrl.csr_op = NONE;
+        endcase
+
+        ctrl.csr_rd_uses_rs1 = instruction_operation inside {CSRRW, CSRRS, CSRRC};
+        ctrl.csr_wr_uses_rs1 = instruction_operation inside {CSRRS, CSRRC, CSRRSI, CSRRCI};
+
+        // Zbkb sub-ops
+        ctrl.zbkb_is_ror     = ZBKBEnable && instruction_operation == ALU_ROR;
+        ctrl.zbkb_is_rol     = ZBKBEnable && instruction_operation == ALU_ROL;
+        ctrl.zbkb_is_packh   = ZBKBEnable && instruction_operation == ALU_PACKH;
+        ctrl.zbkb_is_orn     = ZBKBEnable && instruction_operation == ALU_ORN;
+        ctrl.zbkb_is_andn    = ZBKBEnable && instruction_operation == ALU_ANDN;
+        ctrl.zbkb_is_rev8    = ZBKBEnable && instruction_operation == ALU_REV8;
+        ctrl.zbkb_is_brev8   = ZBKBEnable && instruction_operation == ALU_BREV8;
+        ctrl.zbkb_is_zip     = ZBKBEnable && instruction_operation == ALU_ZIP;
+        ctrl.zbkb_is_unzip   = ZBKBEnable && instruction_operation == ALU_UNZIP;
+        ctrl.zbkb_is_xnor    = ZBKBEnable && instruction_operation == ALU_XNOR;
+
+        ctrl.amo_op          = amo_op_next;
+
+        // Pipeline status fields
+        ctrl.compressed            = ctrl_i.compressed;
+        ctrl.bp_taken              = bp_take_o;
+        ctrl.exc_ilegal_inst       = invalid_inst;
+        ctrl.exc_inst_access_fault = exc_inst_access_fault;
+        ctrl.hazard                = hazard;
+        ctrl.killed                = killed;
+    end
+
+    always_ff @(posedge clk or negedge reset_n) begin
+        if (!reset_n)
+            ctrl_o <= '0;
+        else if (sys_reset)
+            ctrl_o <= '0;
+        else if (enable) begin
+            if (hazard || killed) begin
+                ctrl_o        <= '0;
+                ctrl_o.hazard <= hazard;
+                ctrl_o.killed <= killed;
+            end
+            else
+                ctrl_o <= ctrl;
         end
     end
 

--- a/rtl/decode.sv
+++ b/rtl/decode.sv
@@ -441,6 +441,12 @@ module decode
                     default:             vector_operation = VNOP;
                 endcase
             end
+            else if (instruction_operation == VLOAD) begin
+                vector_operation = VLD;
+            end
+            else if (instruction_operation == VSTORE) begin
+                vector_operation = VST;
+            end
             else begin
                 vector_operation = VNOP;
             end

--- a/rtl/execute.sv
+++ b/rtl/execute.sv
@@ -48,7 +48,6 @@ module execute
     input   logic                   stall,
 
     /* Registered inputs from decode */
-    input   logic                   bp_ack_i,
     input   logic                   valid_i,
     input   logic  [4:0]            rd_i,
     input   logic  [4:0]            rs1_i,
@@ -57,9 +56,17 @@ module execute
     input   logic [31:0]            rs2_data_i,
     input   logic [31:0]            second_operand_i,
     input   logic [31:0]            jump_imm_target_i,
+    /* Not used without branch prediction */
+    /* verilator lint_off UNUSEDSIGNAL */
+    input   logic                   bp_ack_i,
+    /* verilator lint_on UNUSEDSIGNAL */
+
+    /* Some bits of the control signals are not used depending on the ISEs */
+    /* verilator lint_off UNUSEDSIGNAL */
     input   exec_ctrl_t             ctrl_i,
     input   logic [11:0]            csr_address_i,
     input   logic [31:0]            instruction_i,
+    /* verilator lint_on UNUSEDSIGNAL */
 
     /* Combinational inputs from mem_access */
     input   logic                   exc_load_access_fault_i,
@@ -157,23 +164,26 @@ module execute
 
     logic [31:0] xkyber_alu_operand_a, xkyber_alu_operand_b;
 
+    /* Both arms fold to constant 0 when AMO and XKYBER are disabled */
+    /* verilator lint_off CASEOVERLAP */
     always_comb begin
         unique case (1'b1)
             (AMOEXT inside {AMO_A, AMO_ZAAMO} && ctrl_i.is_amo):
                 first_operand = amo_operand;
-            (XKYBEREnable && ctrl_i.is_kyber): 
+            (XKYBEREnable && ctrl_i.is_kyber):
                 first_operand = xkyber_alu_operand_a;
             default:
                 first_operand = rs1_data_i;
         endcase
     end
+    /* verilator lint_on CASEOVERLAP */
 
     logic kyber_uses_opB;
     assign kyber_uses_opB = ctrl_i.kyber_op inside {KYBSUB, KYBMUL, KYBCOMPRESS};
 
     always_comb begin
         unique case (1'b1)
-            ctrl.is_sub:
+            ctrl_i.is_sub:
                 sum_opB = -second_operand_i;
             (XKYBEREnable && kyber_uses_opB):
                 sum_opB = xkyber_alu_operand_b;

--- a/rtl/execute.sv
+++ b/rtl/execute.sv
@@ -47,99 +47,77 @@ module execute
     input   logic                   reset_n,
     input   logic                   stall,
 
-    /* Not used without BP */
-    /* verilator lint_off UNUSEDSIGNAL */
+    /* Registered inputs from decode */
     input   logic                   bp_ack_i,
-    /* verilator lint_on UNUSEDSIGNAL */
-
-    /* Bits 14:12 and 6:0 are not used in this module */
-    /* verilator lint_off UNUSEDSIGNAL */
-    input   logic [31:0]            instruction_i,
-    /* verilator lint_on UNUSEDSIGNAL */
-
+    input   logic                   valid_i,
+    input   logic  [4:0]            rd_i,
+    input   logic  [4:0]            rs1_i,
+    input   logic [31:0]            pc_i,
     input   logic [31:0]            rs1_data_i,
     input   logic [31:0]            rs2_data_i,
     input   logic [31:0]            second_operand_i,
-    input   logic  [4:0]            rd_i,
-    input   logic  [4:0]            rs1_i,
+    input   logic [31:0]            jump_imm_target_i,
+    /* We do not use some bits of these fields if some extensions are off */
+    /* verilator lint_off UNUSEDSIGNAL */
+    input   exec_ctrl_t             ctrl_i,
+    input   logic [11:0]            csr_address_i,
+    input   logic [31:0]            instruction_i,
     input   iType_e                 instruction_operation_i,
-
-    /* Not used without zaamo */
-    /* verilator lint_off UNUSEDSIGNAL */
-    input   iTypeAtomic_e           atomic_operation_i,
-    /* verilator lint_on UNUSEDSIGNAL */
-
-    /* Not used if VEnable is 0 */
-    /* verilator lint_off UNUSEDSIGNAL */
     input   iTypeVector_e           vector_operation_i,
     /* verilator lint_on UNUSEDSIGNAL */
 
-    input   privilegeLevel_e        privilege_i,
-    input   logic                   valid_i,
-    input   logic                   exc_ilegal_inst_i,
-    input   logic                   exc_inst_access_fault_i,
+    /* Combinational inputs from mem_access */
     input   logic                   exc_load_access_fault_i,
+    /* Not used without zalrsc */
+    /* verilator lint_off UNUSEDSIGNAL */
+    input   logic [31:0]            reservation_data_i,
+    /* verilator lint_on UNUSEDSIGNAL */
+    
+    /* CSR interface */
+    input   privilegeLevel_e        privilege_i,
+    input   logic                   interrupt_pending_i,
+    output  logic                   interrupt_ack_o,
+    output  logic                   machine_return_o,
+    output  logic                   raise_exception_o,
+    output  logic                   csr_read_enable_o,
+    output  logic                   csr_write_enable_o,
+    output  csrOperation_e          csr_operation_o,
+    output  exceptionCode_e         exception_code_o,
+    input   logic [31:0]            csr_data_read_i,
+    output  logic [31:0]            csr_data_o,
+    input   logic [31:0]            mtvec_i,
+    input   logic [31:0]            mepc_i,
+    output  logic [31:0]            vtype_o,
+    output  logic [31:0]            vlen_o,
+    output  logic [31:0]            pc_irq_o,
+    output  logic [31:0]            pc_exc_o,
 
-    output  logic                   hold_o,
-    output  logic                   write_enable_o,
-    output  logic                   write_enable_fwd_o,
-    output  iType_e                 instruction_operation_o,
-    output  logic   [31:0]          result_o,
-    output  logic   [31:0]          result_fwd_o,
-    output  logic   [ 4:0]          rd_o,
-
+    /* Memory interface */
     output  logic [31:0]            mem_address_exec_o,
     output  logic [31:0]            mem_address_o,
     output  logic                   mem_enable_o,
     output  logic [BUS_WIDTH/8-1:0] mem_write_enable_o,
     output  logic [BUS_WIDTH-1:0]   mem_write_data_o,
-    /* Not used if VEnable is 0 */
+    /* Not used if VEnable or AMO is 0 */
     /* verilator lint_off UNUSEDSIGNAL */
     input   logic [BUS_WIDTH-1:0]   mem_read_data_i,
     /* verilator lint_on UNUSEDSIGNAL */
 
-    /* We only use some bits of this signal here */
-    /* verilator lint_off UNUSEDSIGNAL */
-    input   logic [11:0]            csr_address_i,
-    /* verilator lint_on UNUSEDSIGNAL */
-    output  logic                   csr_read_enable_o,
-    input   logic [31:0]            csr_data_read_i,
-    output  logic                   csr_write_enable_o,
-    output  csrOperation_e          csr_operation_o,
-    output  logic [31:0]            csr_data_o,
-
-    output  logic [31:0]            vtype_o,
-    output  logic [31:0]            vlen_o,
-
-    /* Not used if BP is off */
-    /* verilator lint_off UNUSEDSIGNAL */
-    input   logic                   bp_taken_i,
-    /* verilator lint_on UNUSEDSIGNAL */
+    /* Combinational outputs to previous stages */
+    output  logic                   hold_o,
+    output  logic                   write_enable_fwd_o,
     output  logic                   jump_rollback_o,
     output  logic                   ctx_switch_o,
-    output  logic [31:0]            ctx_switch_target_o,
-
-    input   logic                   interrupt_pending_i,
-    input   logic                   compressed_i,
-    input   logic [31:0]            mtvec_i,
-    input   logic [31:0]            mepc_i,
-    input   logic [31:0]            jump_imm_target_i,
-    input   logic [31:0]            pc_i,
-
-    /* Not used without zalrsc */
-    /* verilator lint_off UNUSEDSIGNAL */
-    input   logic [31:0]            reservation_data_i,
-    /* verilator lint_on UNUSEDSIGNAL */
-
     output  logic                   jump_o,
     output  logic                   should_jump_o,
-    output  logic                   interrupt_ack_o,
-    output  logic                   machine_return_o,
-    output  logic                   raise_exception_o,
-    output  logic [31:0]            pc_irq_o,
-    output  logic [31:0]            pc_exc_o,
-    output  logic [31:0]            jump_target_o,
-    output  exceptionCode_e         exception_code_o
+    output  logic   [31:0]          ctx_switch_target_o,
+    output  logic   [31:0]          jump_target_o,
+    output  logic   [31:0]          result_fwd_o,
+
+    /* Registered outputs to mem_access */
+    output  wb_ctrl_t               ctrl_o,
+    output  logic   [ 4:0]          rd_o,
+    output  logic   [31:0]          result_o
 );
 
     logic [31:0]    result;
@@ -223,7 +201,7 @@ module execute
     /* We can't obtain the PC from fetch stage because it can be modified due */
     /* to load/store stalls when the current instruction is JAL[R]            */
     logic [31:0] pc_next;
-    assign pc_next = pc_i + (compressed_i ? 32'h00000002 : 32'h00000004);
+    assign pc_next = pc_i + (ctrl_i.compressed ? 32'h00000002 : 32'h00000004);
 
 //////////////////////////////////////////////////////////////////////////////
 // Load/Store signals
@@ -246,13 +224,10 @@ module execute
     logic        atomic_mem_write_enable;
 
     always_comb begin
-        unique case (instruction_operation_i)
-            AMO_W,
-            LR_W,
-            SC_W:    mem_address = (AMOEXT != AMO_OFF) ? rs1_data_i : sum_result;
-            VLOAD,
-            VSTORE:  mem_address = VEnable ? mem_address_vector     : sum_result;
-            default: mem_address = sum_result;
+        unique case (1'b1)
+            ctrl_i.is_amo_w: mem_address = rs1_data_i;
+            ctrl_i.is_vector: mem_address = mem_address_vector;
+            default:          mem_address = sum_result;
         endcase
     end
 
@@ -264,16 +239,16 @@ module execute
     end
 
     logic misaligned_sh;
-    assign misaligned_sh = mem_address[0] && (instruction_operation_i == SH);
+    assign misaligned_sh = mem_address[0]        && ctrl_i.is_half && ctrl_i.is_store;
 
     logic misaligned_sw;
-    assign misaligned_sw = (mem_address[1:0] != '0) && (instruction_operation_i inside {SW, AMO_W, LR_W, SC_W});
+    assign misaligned_sw = (mem_address[1:0] != '0) && (ctrl_i.is_amo_w || (ctrl_i.is_store && !ctrl_i.is_half && !ctrl_i.is_byte));
 
     logic misaligned_lh;
-    assign misaligned_lh = mem_address[0] && (instruction_operation_i inside {LH, LHU});
+    assign misaligned_lh = mem_address[0]        && ctrl_i.is_half && ctrl_i.is_load;
 
     logic misaligned_lw;
-    assign misaligned_lw = (mem_address[1:0] != '0) && (instruction_operation_i == LW);
+    assign misaligned_lw = (mem_address[1:0] != '0) && ctrl_i.is_load && !ctrl_i.is_half && !ctrl_i.is_byte;
 
     logic laddr_misaligned;
     assign laddr_misaligned = (misaligned_lh || misaligned_lw);
@@ -282,19 +257,19 @@ module execute
     assign saddr_misaligned = (misaligned_sh || misaligned_sw);
 
     logic mem_read_enable_vector_inst;
-    assign mem_read_enable_vector_inst = mem_read_enable_vector && (instruction_operation_i inside {VLOAD, VSTORE});
+    assign mem_read_enable_vector_inst = mem_read_enable_vector && ctrl_i.is_vector;
 
     logic mem_read_enable;
-    assign mem_read_enable = instruction_operation_i inside {LB, LBU, LH, LHU, LW, LR_W};
+    assign mem_read_enable = ctrl_i.is_load || ctrl_i.is_lr;
 
     logic pmem_read_enable;
     assign pmem_read_enable = (mem_read_enable || atomic_mem_read_enable || mem_read_enable_vector_inst);
 
     always_comb begin
-        unique case (instruction_operation_i)
-            SB:         mem_write_data = {4{rs2_data_i[7:0]}};
-            SH:         mem_write_data = {2{rs2_data_i[15:0]}};
-            default:    mem_write_data = rs2_data_i;
+        unique case (1'b1)
+            ctrl_i.is_byte: mem_write_data = {4{rs2_data_i[7:0]}};
+            ctrl_i.is_half: mem_write_data = {2{rs2_data_i[15:0]}};
+            default:        mem_write_data = rs2_data_i;
         endcase
     end
 
@@ -303,23 +278,23 @@ module execute
             mem_write_data_o <= '0;
         end
         else if (!stall) begin
-            unique case (instruction_operation_i)
-                VLOAD,
-                VSTORE:  mem_write_data_o <= VEnable ? mem_write_data_vector : {{(BUS_WIDTH-32){1'b0}}, mem_write_data};
-                AMO_W:   mem_write_data_o <= {{(BUS_WIDTH-32){1'b0}}, ((AMOEXT inside {AMO_ZAAMO, AMO_A}) ? amo_operand : mem_write_data)};
-                default: mem_write_data_o <= {{(BUS_WIDTH-32){1'b0}}, mem_write_data};
+            unique case (1'b1)
+                ctrl_i.is_vector: mem_write_data_o <= mem_write_data_vector;
+                ctrl_i.is_amo:    mem_write_data_o <= {{(BUS_WIDTH-32){1'b0}}, amo_operand};
+                default:          mem_write_data_o <= {{(BUS_WIDTH-32){1'b0}}, mem_write_data};
             endcase
         end
     end
 
     always_comb begin
         mem_write_enable = '0;
-        unique case (instruction_operation_i)
-            SB:      mem_write_enable[sum_result[1:0]]      = 1'b1;
-            SH:      mem_write_enable[sum_result[1:0]+1-:2] = 2'b11;
-            SW:      mem_write_enable                       = 4'b1111;
-            default: mem_write_enable                       = '0;
-        endcase
+        if (ctrl_i.is_store) begin
+            unique case (1'b1)
+                ctrl_i.is_byte: mem_write_enable[sum_result[1:0]]      = 1'b1;
+                ctrl_i.is_half: mem_write_enable[sum_result[1:0]+1-:2] = 2'b11;
+                default:        mem_write_enable                        = 4'b1111;
+            endcase
+        end
     end
 
     logic [BUS_WIDTH/8-1:0] pmem_write_enable;
@@ -356,45 +331,10 @@ module execute
     assign csr_read_enable_o  = csr_read_enable  && !exc_ilegal_csr_inst && !stall;
     assign csr_write_enable_o = csr_write_enable && !exc_ilegal_csr_inst && !stall;
 
-    always_comb begin
-        unique case (instruction_operation_i)
-            CSRRW,
-            CSRRWI:  csr_read_enable = (rd_i != '0);
-            CSRRS,
-            CSRRC,
-            CSRRSI,
-            CSRRCI:  csr_read_enable = 1'b1;
-            default: csr_read_enable  = 1'b0;
-        endcase
-    end
-
-    always_comb begin
-        unique case (instruction_operation_i)
-            CSRRW,
-            CSRRWI:  csr_write_enable = 1'b1;
-            CSRRS,
-            CSRRC,
-            CSRRSI,
-            CSRRCI:  csr_write_enable = (rs1_i != '0);
-            default: csr_write_enable = 1'b0;
-        endcase
-    end
-
-    always_comb begin
-        unique case (instruction_operation_i)
-            CSRRW, CSRRS, CSRRC:    csr_data_o = rs1_data_i;
-            default:                csr_data_o = {27'b0, rs1_i};
-        endcase
-    end
-
-    always_comb begin
-        unique case (instruction_operation_i)
-            CSRRW, CSRRWI:  csr_operation_o = WRITE;
-            CSRRS, CSRRSI:  csr_operation_o = SET;
-            CSRRC, CSRRCI:  csr_operation_o = CLEAR;
-            default:        csr_operation_o = NONE;
-        endcase
-    end
+    assign csr_read_enable  = ctrl_i.is_csr && (ctrl_i.csr_op == WRITE ? (rd_i != '0) : 1'b1);
+    assign csr_write_enable = ctrl_i.is_csr && (ctrl_i.csr_wr_uses_rs1 ? (rs1_i != '0) : 1'b1);
+    assign csr_data_o       = ctrl_i.csr_rd_uses_rs1 ? rs1_data_i : {27'b0, rs1_i};
+    assign csr_operation_o  = ctrl_i.csr_op;
 
     assign exc_ilegal_csr_inst = (
         (csr_write_enable && csr_address_i[11:10] == 2'b11) ||
@@ -482,16 +422,9 @@ module execute
         logic       enable_mul;
         logic       mul_low;
 
-        always_comb begin
-            unique case (instruction_operation_i)
-                MULH:    signed_mode_mul = 2'b11;
-                MULHSU:  signed_mode_mul = 2'b01;
-                default: signed_mode_mul = 2'b00;
-            endcase
-        end
-
-        assign enable_mul = (instruction_operation_i inside {MUL, MULH, MULHU, MULHSU});
-        assign mul_low    = (instruction_operation_i == MUL);
+        assign signed_mode_mul = ctrl_i.mul_signed_mode;
+        assign enable_mul      = ctrl_i.is_mul;
+        assign mul_low         = ctrl_i.mul_low;
 
         logic [31:0] mul_first_operand, mul_second_operand;
 
@@ -529,8 +462,8 @@ module execute
         logic enable_div;
         logic signed_div;
 
-        assign enable_div = (instruction_operation_i inside {DIV, DIVU, REM, REMU});
-        assign signed_div = (instruction_operation_i inside {DIV, REM});
+        assign enable_div = ctrl_i.is_div || ctrl_i.is_rem;
+        assign signed_div = ctrl_i.div_signed;
 
         div div1 (
             .clk              (clk),
@@ -560,8 +493,8 @@ module execute
         logic aes_mix;
         logic aes_valid;
 
-        assign aes_mix = (instruction_operation_i == AES32ESMI);
-        assign aes_valid = (instruction_operation_i inside {AES32ESMI, AES32ESI});
+        assign aes_mix   = ctrl_i.aes_is_mix;
+        assign aes_valid = ctrl_i.is_aes;
 
         aes_unit #(
             .Environment (Environment),
@@ -671,16 +604,16 @@ module execute
                     reservation_addr <= '0;
                 end
                 else if (!stall) begin
-                    unique case (instruction_operation_i)
-                        LR_W: reservation_addr <= rs1_data_i;
-                        SC_W: reservation_addr <= lrsc_hold ? reservation_addr : '0;
+                    unique case (1'b1)
+                        ctrl_i.is_lr: reservation_addr <= rs1_data_i;
+                        ctrl_i.is_sc: reservation_addr <= lrsc_hold ? reservation_addr : '0;
                         default: ;
                     endcase
                 end
             end
 
             logic lrsc_enable;
-            assign lrsc_enable = (instruction_operation_i == SC_W) && (rs1_data_i[1:0] == '0);
+            assign lrsc_enable = ctrl_i.is_sc && (rs1_data_i[1:0] == '0);
 
             logic [31:0] cmp_opA;
             logic [31:0] cmp_opB;
@@ -725,7 +658,7 @@ module execute
 
         if (AMOEXT != AMO_ZALRSC) begin : gen_zaamo_on
             logic amo_enable;
-            assign amo_enable = (instruction_operation_i == AMO_W) && (rs1_data_i[1:0] == '0);
+            assign amo_enable = ctrl_i.is_amo && (rs1_data_i[1:0] == '0);
 
             logic amo_lt;
             assign amo_lt = $signed(amo_operand) < $signed(rs2_data_i);
@@ -735,7 +668,7 @@ module execute
 
             logic [31:0] amo_result;
             always_comb begin
-                unique case (atomic_operation_i)
+                unique case (ctrl_i.amo_op)
                     AMOADD:  amo_result = sum_result;
                     AMOAND:  amo_result = and_result;
                     AMOXOR:  amo_result = xor_result;
@@ -796,12 +729,9 @@ module execute
     logic [31:0] result_zicond;
 
     if (ZICONDEnable) begin : gen_zicond_on
-        always_comb begin
-            unique case (instruction_operation_i)
-                CZERO_EQZ: result_zicond = rs2_data_i == '0 ? '0 : rs1_data_i;
-                default:   result_zicond = rs2_data_i != '0 ? '0 : rs1_data_i; // CZERO_NEZ
-            endcase
-        end
+        assign result_zicond = ctrl_i.zicond_is_eqz
+            ? (rs2_data_i == '0 ? '0 : rs1_data_i)   // CZERO_EQZ
+            : (rs2_data_i != '0 ? '0 : rs1_data_i);  // CZERO_NEZ
     end
     else begin : gen_zicond_off
         assign result_zicond = '0;
@@ -822,21 +752,16 @@ module execute
         //////////
         // Pack //
         //////////
-        logic packh;
-        assign packh = (instruction_operation_i == ALU_PACKH);
-
         always_comb begin
             unique case (1'b1)
-                packh:   pack_result = {16'h0, second_operand_i[7:0], rs1_data_i[7:0]};
-                default: pack_result = {second_operand_i[15:0], rs1_data_i[15:0]};
+                ctrl_i.zbkb_is_packh: pack_result = {16'h0, second_operand_i[7:0], rs1_data_i[7:0]};
+                default:              pack_result = {second_operand_i[15:0], rs1_data_i[15:0]};
             endcase
         end
 
         ///////////////////
         // Bitwise Logic //
         ///////////////////
-        logic bwlogic_or;
-        logic bwlogic_and;
         logic [31:0] bwlogic_operand_b;
         logic [31:0] bwlogic_or_result;
         logic [31:0] bwlogic_and_result;
@@ -848,14 +773,11 @@ module execute
         assign bwlogic_and_result = rs1_data_i & bwlogic_operand_b;
         assign bwlogic_xor_result = rs1_data_i ^ bwlogic_operand_b;
 
-        assign bwlogic_or  = (instruction_operation_i == ALU_ORN);
-        assign bwlogic_and = (instruction_operation_i == ALU_ANDN);
-
         always_comb begin
             unique case (1'b1)
-                bwlogic_or:  bwlogic_result = bwlogic_or_result;
-                bwlogic_and: bwlogic_result = bwlogic_and_result;
-                default:     bwlogic_result = bwlogic_xor_result;
+                ctrl_i.zbkb_is_orn:  bwlogic_result = bwlogic_or_result;
+                ctrl_i.zbkb_is_andn: bwlogic_result = bwlogic_and_result;
+                default:             bwlogic_result = bwlogic_xor_result;
             endcase
         end
 
@@ -896,10 +818,7 @@ module execute
         end
 
         always_comb begin
-            logic is_zip;
-            is_zip = instruction_operation_i == ALU_ZIP;
-
-            if (is_zip) begin
+            if (ctrl_i.zbkb_is_zip) begin
                 for (int i = 0; i < 16; i++) begin
                     shuffle_result[2*i] = rs1_data_i[i];
                     shuffle_result[2*i + 1] = rs1_data_i[i + 16];
@@ -922,7 +841,7 @@ module execute
 
         assign ror_result   =  srl_result | (rs1_data_i << shift_amt_compl);
         assign rol_result   =  sll_result | (rs1_data_i >> shift_amt_compl);
-        assign shift_result = (instruction_operation_i == ALU_ROL) ? rol_result : ror_result;
+        assign shift_result = ctrl_i.zbkb_is_rol ? rol_result : ror_result;
     end
     else begin : gen_zbkb_off
         assign shift_result   = '0;   
@@ -937,37 +856,45 @@ module execute
 //////////////////////////////////////////////////////////////////////////////
 
     always_comb begin
-        unique case (instruction_operation_i)
-            CSRRW, CSRRS, CSRRC,
-            CSRRWI,CSRRSI,CSRRCI:                   result = csr_data_read_i;
-            JAL,JALR:                               result = pc_next;
-            SLT:                                    result = {31'b0, less_than};
-            SLTU:                                   result = {31'b0, less_than_unsigned};
-            XOR:                                    result = xor_result;
-            OR:                                     result = or_result;
-            AND:                                    result = and_result;
-            SLL:                                    result = sll_result;
-            SRL:                                    result = srl_result;
-            SRA:                                    result = sra_result;
-            LUI:                                    result = second_operand_i;
-            AUIPC:                                  result = jump_imm_target_i;
-            DIV,DIVU:                               result = (MULEXT == MUL_M)   ? div_result                           : sum_result;
-            REM,REMU:                               result = (MULEXT == MUL_M)   ? rem_result                           : sum_result;
-            MUL,MULH,MULHU,MULHSU:                  result = (MULEXT != MUL_OFF) ? mul_result                           : sum_result;
-            AES32ESI, AES32ESMI:                    result = ZKNEEnable          ? aes_result                           : sum_result;
-            VECTOR, VLOAD, VSTORE:                  result = VEnable             ? vector_scalar_result                 : sum_result;
-            CZERO_EQZ, CZERO_NEZ:                   result = ZICONDEnable        ? result_zicond                        : sum_result;
-            SC_W:                                   result = (AMOEXT inside {AMO_ZALRSC, AMO_A}) ? {31'h0, lrsc_result} : sum_result;
-            SIG0H,SIG0L,SIG1H,SIG1L,SUM0R,
-            SUM1R,SIG0,SIG1,SUM0,SUM1:              result = (ZKNHEnable)   ? sha2_result    : sum_result;
-            ALU_ROR, ALU_ROL:                       result = (ZBKBEnable)   ? shift_result   : sum_result;
-            ALU_PACK, ALU_PACKH:                    result = (ZBKBEnable)   ? pack_result    : sum_result; 
-            ALU_XNOR, ALU_ORN, ALU_ANDN:            result = (ZBKBEnable)   ? bwlogic_result : sum_result;
-            ALU_REV8, ALU_BREV8:                    result = (ZBKBEnable)   ? rev_result     : sum_result;
-            ALU_ZIP, ALU_UNZIP:                     result = (ZBKBEnable)   ? shuffle_result : sum_result;        
-            KYBER_ADD, KYBER_SUB, KYBER_CBD2, 
-            KYBER_CBD3, KYBER_MUL, KYBER_COMPRESS:  result = (XKYBEREnable) ? xkyber_result  : sum_result;  
-            default:                                result = sum_result;
+        unique case (1'b1)
+            ctrl_i.is_csr:          result = csr_data_read_i;
+            ctrl_i.is_jal_jalr:     result = pc_next;
+            ctrl_i.is_slt:          result = {31'b0, less_than};
+            ctrl_i.is_sltu:         result = {31'b0, less_than_unsigned};
+            ctrl_i.is_xor:          result = xor_result;
+            ctrl_i.is_or:           result = or_result;
+            ctrl_i.is_and:          result = and_result;
+            ctrl_i.is_sll:          result = sll_result;
+            ctrl_i.is_srl:          result = srl_result;
+            ctrl_i.is_sra:          result = sra_result;
+            ctrl_i.is_lui:          result = second_operand_i;
+            ctrl_i.is_auipc:        result = jump_imm_target_i;
+            ctrl_i.is_div:          result = (MULEXT == MUL_M)          ? div_result                           : sum_result;
+            ctrl_i.is_rem:          result = (MULEXT == MUL_M)          ? rem_result                           : sum_result;
+            ctrl_i.is_mul:          result = (MULEXT != MUL_OFF)        ? mul_result                           : sum_result;
+            ctrl_i.is_aes:          result = ZKNEEnable                 ? aes_result                           : sum_result;
+            ctrl_i.is_vector:       result = VEnable                    ? vector_scalar_result                 : sum_result;
+            ctrl_i.is_zicond:       result = ZICONDEnable               ? result_zicond                        : sum_result;
+            ctrl_i.is_sc:           result = (AMOEXT inside {AMO_ZALRSC, AMO_A}) ? {31'h0, lrsc_result}       : sum_result;
+            ctrl_i.zbkb_is_ror:     result = ZBKBEnable                 ? shift_result                         : sum_result;
+            ctrl_i.zbkb_is_rol:     result = ZBKBEnable                 ? shift_result                         : sum_result;
+            ctrl_i.zbkb_is_orn:     result = ZBKBEnable                 ? bwlogic_result                       : sum_result;
+            ctrl_i.zbkb_is_andn:    result = ZBKBEnable                 ? bwlogic_result                       : sum_result;
+            ctrl_i.zbkb_is_rev8:    result = ZBKBEnable                 ? rev_result                           : sum_result;
+            ctrl_i.zbkb_is_brev8:   result = ZBKBEnable                 ? rev_result                           : sum_result;
+            ctrl_i.zbkb_is_zip:     result = ZBKBEnable                 ? shuffle_result                       : sum_result;
+            ctrl_i.zbkb_is_unzip:   result = ZBKBEnable                 ? shuffle_result                       : sum_result;
+            ctrl_i.zbkb_is_xnor:    result = ZBKBEnable                 ? bwlogic_result                       : sum_result;
+            ctrl_i.is_zbkb:         result = ZBKBEnable                 ? pack_result                          : sum_result;
+            default: begin
+                /* SHA2/Kyber ops set no ctrl one-hot bit, so they land here */
+                if (ZKNHEnable && instruction_operation_i inside {SIG0H, SIG0L, SIG1H, SIG1L, SUM0R, SUM1R, SIG0, SIG1, SUM0, SUM1})
+                    result = sha2_result;
+                else if (XKYBEREnable && is_xkyber)
+                    result = xkyber_result;
+                else
+                    result = sum_result;
+            end
         endcase
     end
 
@@ -975,21 +902,14 @@ module execute
     assign we_atomic  = (rd_i != '0 && atomic_write_enable);
 
     logic we_default;
-    assign we_default = (rd_i != '0 && !hold_o && !raise_exception);
+    assign we_default = (ctrl_i.rd_we && rd_i != '0 && !hold_o && !raise_exception);
 
     always_comb begin
-        unique case (instruction_operation_i)
-            NOP,
-            SB,SH,SW,
-            BEQ,BNE,
-            BLT,BLTU,
-            BGE,BGEU:   write_enable = 1'b0;
-            VECTOR,
-            VLOAD,
-            VSTORE:     write_enable = VEnable ? (rd_i != '0 && vector_wr_en)          : we_default;
-            SC_W:       write_enable = (AMOEXT inside {AMO_ZALRSC, AMO_A}) ? we_atomic : we_default ;
-            AMO_W:      write_enable = (AMOEXT inside {AMO_ZAAMO,  AMO_A}) ? we_atomic : we_default ;
-            default:    write_enable = we_default;
+        unique case (1'b1)
+            ctrl_i.is_vector:   write_enable = ctrl_i.rd_we && rd_i != '0 && vector_wr_en;
+            ctrl_i.is_sc:       write_enable = we_atomic;
+            ctrl_i.is_amo:      write_enable = we_atomic;
+            default:            write_enable = we_default;
         endcase
     end
 
@@ -1001,30 +921,23 @@ module execute
 
     assign hold_o = (hold_div || hold_mul  || hold_xkyber || hold_vector || atomic_hold) && !exc_load_access_fault_i;
 
-    always_ff @(posedge clk or negedge reset_n) begin
-        if (!reset_n)
-            write_enable_o <= 1'b0;
-        else if (!stall)
-            write_enable_o <= write_enable;
+    wb_ctrl_t wb_ctrl_next;
+    always_comb begin
+        wb_ctrl_next.rd_we       = write_enable;
+        wb_ctrl_next.is_load     = ctrl_i.is_load || (ctrl_i.is_sc && !atomic_write_enable)
+                                                   || (ctrl_i.is_amo && atomic_write_enable);
+        wb_ctrl_next.is_lr       = ctrl_i.is_lr;
+        wb_ctrl_next.is_sc       = ctrl_i.is_sc;
+        wb_ctrl_next.is_byte     = ctrl_i.is_byte;
+        wb_ctrl_next.is_half     = ctrl_i.is_half;
+        wb_ctrl_next.is_unsigned = ctrl_i.is_unsigned;
     end
 
-    iType_e sc_instruction;
-    assign sc_instruction = atomic_write_enable ? instruction_operation_i : LW;
-
-    iType_e amo_instruction;
-    assign amo_instruction = !atomic_write_enable ? instruction_operation_i : LW;
-
     always_ff @(posedge clk or negedge reset_n) begin
-        if (!reset_n) begin
-            instruction_operation_o <= NOP;
-        end
-        else if (!stall) begin
-            unique case (instruction_operation_i)
-                SC_W:    instruction_operation_o <= (AMOEXT inside {AMO_ZALRSC, AMO_A}) ? sc_instruction  : instruction_operation_i;
-                AMO_W:   instruction_operation_o <= (AMOEXT inside {AMO_ZAAMO,  AMO_A}) ? amo_instruction : instruction_operation_i;
-                default: instruction_operation_o <= instruction_operation_i;
-            endcase
-        end
+        if (!reset_n)
+            ctrl_o <= '0;
+        else if (!stall)
+            ctrl_o <= wb_ctrl_next;
     end
 
     always_ff @(posedge clk or negedge reset_n) begin
@@ -1047,24 +960,19 @@ module execute
 // BRANCH CONTROL
 //////////////////////////////////////////////////////////////////////////////
 
-    always_comb begin
-        unique case (instruction_operation_i)
-            JALR:       jump_target_o = {sum_result[31:1], 1'b0};
-            default:    jump_target_o = jump_imm_target_i;
-        endcase
-    end
+    assign jump_target_o = ctrl_i.is_jalr ? {sum_result[31:1], 1'b0} : jump_imm_target_i;
 
     logic should_jump;
     always_comb begin
-        unique case (instruction_operation_i)
-            BEQ:        should_jump = equal;
-            BNE:        should_jump = !equal;
-            BLT:        should_jump = less_than;
-            BLTU:       should_jump = less_than_unsigned;
-            BGE:        should_jump = greater_equal;
-            BGEU:       should_jump = greater_equal_unsigned;
-            JAL, JALR:  should_jump = 1'b1;
-            default:    should_jump = 1'b0;
+        unique case (1'b1)
+            ctrl_i.is_beq:      should_jump = equal;
+            ctrl_i.is_bne:      should_jump = !equal;
+            ctrl_i.is_blt:      should_jump = less_than;
+            ctrl_i.is_bltu:     should_jump = less_than_unsigned;
+            ctrl_i.is_bge:      should_jump = greater_equal;
+            ctrl_i.is_bgeu:     should_jump = greater_equal_unsigned;
+            ctrl_i.is_jal_jalr: should_jump = 1'b1;
+            default:            should_jump = 1'b0;
         endcase
     end
 
@@ -1081,8 +989,8 @@ module execute
     /* (and decoding)                                                       */
     logic jump;
     if (BRANCHPRED) begin : gen_bp_on
-        assign jump            = ( should_jump && !(bp_taken_i && bp_ack_i));
-        assign jump_rollback_o = (!should_jump &&  (bp_taken_i && bp_ack_i));
+        assign jump            = ( should_jump && !(ctrl_i.bp_taken && bp_ack_i));
+        assign jump_rollback_o = (!should_jump &&  (ctrl_i.bp_taken && bp_ack_i));
     end
     else begin : gen_bp_off
         assign jump            = should_jump;
@@ -1117,16 +1025,16 @@ module execute
 //////////////////////////////////////////////////////////////////////////////
 
     logic illegal_mret;
-    assign illegal_mret = (instruction_operation_i == MRET) && (privilege_i != 2'b11);
+    assign illegal_mret = ctrl_i.is_mret && (privilege_i != 2'b11);
 
     /* We can't change privilege until the end of the instruction */
     /* Hence, exception, ret and irq must be masked by stall      */
     assign raise_exception = (
-        exc_inst_access_fault_i ||
-        exc_ilegal_inst_i ||
+        ctrl_i.exc_inst_access_fault ||
+        ctrl_i.exc_ilegal_inst ||
         exc_load_access_fault_i ||
         illegal_mret ||
-        instruction_operation_i inside {ECALL, EBREAK} ||
+        ctrl_i.is_ecall || ctrl_i.is_ebreak ||
         exc_ilegal_csr_inst ||
         iaddr_misaligned ||
         laddr_misaligned ||
@@ -1134,7 +1042,7 @@ module execute
     );
     assign raise_exception_o = raise_exception && !stall;
 
-    assign machine_return   = (instruction_operation_i == MRET) && (privilege_i == 2'b11);
+    assign machine_return   = ctrl_i.is_mret && (privilege_i == 2'b11);
     assign machine_return_o = machine_return && !stall;
 
     assign interrupt_ack = (
@@ -1150,15 +1058,15 @@ module execute
     always_comb begin
         if (exc_load_access_fault_i)    /* Highest priority because it happened last cycle */
             exception_code_o  = LOAD_ACCESS_FAULT;
-        else if (exc_inst_access_fault_i)
+        else if (ctrl_i.exc_inst_access_fault)
             exception_code_o  = INSTRUCTION_ACCESS_FAULT;
-        else if (exc_ilegal_inst_i || exc_ilegal_csr_inst || illegal_mret)
+        else if (ctrl_i.exc_ilegal_inst || exc_ilegal_csr_inst || illegal_mret)
             exception_code_o  = ILLEGAL_INSTRUCTION;
         else if (iaddr_misaligned)
             exception_code_o  = INSTRUCTION_ADDRESS_MISALIGNED;
-        else if (instruction_operation_i == ECALL)
+        else if (ctrl_i.is_ecall)
             exception_code_o  = (privilege_i == USER) ? ECALL_FROM_UMODE : ECALL_FROM_MMODE;
-        else if (instruction_operation_i == EBREAK)
+        else if (ctrl_i.is_ebreak)
             exception_code_o  = BREAKPOINT;
         else if (laddr_misaligned)
             exception_code_o  = LOAD_ADDRESS_MISALIGNED;

--- a/rtl/execute.sv
+++ b/rtl/execute.sv
@@ -57,13 +57,9 @@ module execute
     input   logic [31:0]            rs2_data_i,
     input   logic [31:0]            second_operand_i,
     input   logic [31:0]            jump_imm_target_i,
-    /* We do not use some bits of these fields if some extensions are off */
-    /* verilator lint_off UNUSEDSIGNAL */
     input   exec_ctrl_t             ctrl_i,
     input   logic [11:0]            csr_address_i,
     input   logic [31:0]            instruction_i,
-    input   iTypeVector_e           vector_operation_i,
-    /* verilator lint_on UNUSEDSIGNAL */
 
     /* Combinational inputs from mem_access */
     input   logic                   exc_load_access_fault_i,
@@ -141,7 +137,7 @@ module execute
     logic           greater_equal;
     logic           greater_equal_unsigned;
 
-    logic [31:0] sum2_opB;
+    logic [31:0] sum_opB;
 
     // Can be assigned by atomic instructions or rs1_data_i
     logic [31:0] first_operand;
@@ -149,53 +145,49 @@ module execute
     logic [31:0] equal_opB;
 
     /* Unmuxed operators */
-    assign less_than_unsigned      = rs1_data_i <  second_operand_i;
-    assign greater_equal_unsigned  = rs1_data_i >= second_operand_i;
-    assign less_than               = $signed(rs1_data_i) <  $signed(second_operand_i);
-    assign greater_equal           = $signed(rs1_data_i) >= $signed(second_operand_i);
-    assign sll_result              = rs1_data_i << second_operand_i[4:0];
-    assign srl_result              = rs1_data_i >> second_operand_i[4:0];
-    assign sra_result              = $signed(rs1_data_i) >>> second_operand_i[4:0];
+    assign less_than_unsigned     = rs1_data_i <  second_operand_i;
+    assign greater_equal_unsigned = rs1_data_i >= second_operand_i;
+    assign less_than              = $signed(rs1_data_i) <  $signed(second_operand_i);
+    assign greater_equal          = $signed(rs1_data_i) >= $signed(second_operand_i);
+    assign sll_result             = rs1_data_i << second_operand_i[4:0];
+    assign srl_result             = rs1_data_i >> second_operand_i[4:0];
+    assign sra_result             = $signed(rs1_data_i) >>> second_operand_i[4:0];
 
     logic [31:0] amo_operand;
 
     logic [31:0] xkyber_alu_operand_a, xkyber_alu_operand_b;
 
     always_comb begin
-        unique case (instruction_operation_i)
-            AMO_W:
-                first_operand = (AMOEXT inside {AMO_A, AMO_ZAAMO}) ? amo_operand : rs1_data_i;
-            KYBER_ADD, 
-            KYBER_SUB, 
-            KYBER_CBD2, 
-            KYBER_CBD3, 
-            KYBER_MUL, 
-            KYBER_COMPRESS:
-                first_operand = (XKYBEREnable) ? xkyber_alu_operand_a : rs1_data_i;
+        unique case (1'b1)
+            (AMOEXT inside {AMO_A, AMO_ZAAMO} && ctrl_i.is_amo):
+                first_operand = amo_operand;
+            (XKYBEREnable && ctrl_i.is_kyber): 
+                first_operand = xkyber_alu_operand_a;
             default:
                 first_operand = rs1_data_i;
         endcase
     end
 
+    logic kyber_uses_opB;
+    assign kyber_uses_opB = ctrl_i.kyber_op inside {KYBSUB, KYBMUL, KYBCOMPRESS};
+
     always_comb begin
-        unique case (instruction_operation_i)
-            SUB:
-                sum2_opB = -second_operand_i;
-            KYBER_SUB, 
-            KYBER_MUL, 
-            KYBER_COMPRESS:
-                sum2_opB = (XKYBEREnable) ? xkyber_alu_operand_b : second_operand_i;
+        unique case (1'b1)
+            ctrl.is_sub:
+                sum_opB = -second_operand_i;
+            (XKYBEREnable && kyber_uses_opB):
+                sum_opB = xkyber_alu_operand_b;
             default:
-                sum2_opB = second_operand_i; // AMO_W
+                sum_opB = second_operand_i;
         endcase
     end
 
     /* Muxed operators */
-    assign sum_result              = first_operand + sum2_opB;
-    assign and_result              = first_operand & second_operand_i;
-    assign or_result               = first_operand | second_operand_i;
-    assign xor_result              = first_operand ^ second_operand_i;
-    assign equal                   = equal_opA == equal_opB;
+    assign sum_result = first_operand + sum_opB;
+    assign and_result = first_operand & second_operand_i;
+    assign or_result  = first_operand | second_operand_i;
+    assign xor_result = first_operand ^ second_operand_i;
+    assign equal      = equal_opA == equal_opB;
 
     /* We can't obtain the PC from fetch stage because it can be modified due */
     /* to load/store stalls when the current instruction is JAL[R]            */
@@ -224,7 +216,7 @@ module execute
 
     always_comb begin
         unique case (1'b1)
-            ctrl_i.is_amo_w: mem_address = rs1_data_i;
+            ctrl_i.is_amo_w:  mem_address = rs1_data_i;
             ctrl_i.is_vector: mem_address = mem_address_vector;
             default:          mem_address = sum_result;
         endcase
@@ -238,13 +230,13 @@ module execute
     end
 
     logic misaligned_sh;
-    assign misaligned_sh = mem_address[0]        && ctrl_i.is_half && ctrl_i.is_store;
+    assign misaligned_sh = mem_address[0] && ctrl_i.is_half && ctrl_i.is_store;
 
     logic misaligned_sw;
     assign misaligned_sw = (mem_address[1:0] != '0) && (ctrl_i.is_amo_w || (ctrl_i.is_store && !ctrl_i.is_half && !ctrl_i.is_byte));
 
     logic misaligned_lh;
-    assign misaligned_lh = mem_address[0]        && ctrl_i.is_half && ctrl_i.is_load;
+    assign misaligned_lh = mem_address[0] && ctrl_i.is_half && ctrl_i.is_load;
 
     logic misaligned_lw;
     assign misaligned_lw = (mem_address[1:0] != '0) && ctrl_i.is_load && !ctrl_i.is_half && !ctrl_i.is_byte;
@@ -291,7 +283,7 @@ module execute
             unique case (1'b1)
                 ctrl_i.is_byte: mem_write_enable[sum_result[1:0]]      = 1'b1;
                 ctrl_i.is_half: mem_write_enable[sum_result[1:0]+1-:2] = 2'b11;
-                default:        mem_write_enable                        = 4'b1111;
+                default:        mem_write_enable                       = 4'b1111;
             endcase
         end
     end
@@ -325,12 +317,12 @@ module execute
 // CSR access signals
 //////////////////////////////////////////////////////////////////////////////
 
-    logic       csr_read_enable, csr_write_enable;
+    logic csr_read_enable, csr_write_enable;
 
     assign csr_read_enable_o  = csr_read_enable  && !exc_ilegal_csr_inst && !stall;
     assign csr_write_enable_o = csr_write_enable && !exc_ilegal_csr_inst && !stall;
 
-    assign csr_read_enable  = ctrl_i.is_csr && (ctrl_i.csr_op == WRITE ? (rd_i != '0) : 1'b1);
+    assign csr_read_enable  = ctrl_i.is_csr && (ctrl_i.csr_op == WRITE ? (rd_i  != '0) : 1'b1);
     assign csr_write_enable = ctrl_i.is_csr && (ctrl_i.csr_wr_uses_rs1 ? (rs1_i != '0) : 1'b1);
     assign csr_data_o       = ctrl_i.csr_rd_uses_rs1 ? rs1_data_i : {27'b0, rs1_i};
     assign csr_operation_o  = ctrl_i.csr_op;
@@ -348,18 +340,12 @@ module execute
     logic        hold_mul;
     logic        hold_div;
 
-
 /////////////////////////////////////////////////////////////////////////////
 // Xkyber signals
 //////////////////////////////////////////////////////////////////////////////
 
     logic hold_xkyber;
     logic [31:0] xkyber_result;
-
-    logic is_xkyber;
-
-    assign is_xkyber = (instruction_operation_i inside {KYBER_ADD, KYBER_SUB,KYBER_CBD2, KYBER_CBD3, KYBER_MUL, KYBER_COMPRESS});
-
     logic [15:0] mult_kyber_op_a, mult_kyber_op_b;
 
     if (XKYBEREnable) begin : gen_xkyber_on
@@ -368,7 +354,7 @@ module execute
         logic [2:0]  cbd_result_low;
 
         logic eta_is_3;
-        assign eta_is_3 = (instruction_operation_i == KYBER_CBD3);
+        assign eta_is_3 = (ctrl_i.kyber_op == KYBCBD3);
 
         assign cbd_result_high = eta_is_3 ?
             (3'(first_operand[6]) + 3'(first_operand[7]) + 3'(first_operand[8])) -
@@ -383,18 +369,17 @@ module execute
             (3'(first_operand[2]) + 3'(first_operand[3]));
 
         logic [3:0] kyber_compress_bits;
-
-        assign kyber_compress_bits = second_operand_i[3:0] & {4{instruction_operation_i == KYBER_COMPRESS}};
+        assign kyber_compress_bits = second_operand_i[3:0] & {4{ctrl_i.kyber_op == KYBCOMPRESS}};
 
         xkyber xkyber1 (
             .clk                   (clk),
             .reset_n               (reset_n),
             .stall                 (stall),
             .alu_adder_i           (sum_result),
-            .operator_i            (instruction_operation_i),
+            .operator_i            (ctrl_i.kyber_op),
             .first_operand_i       (rs1_data_i),
             .second_operand_i      (rs2_data_i),
-            .is_xkyber_i           (is_xkyber),
+            .is_xkyber_i           (ctrl_i.is_kyber),
             .hold_o                (hold_xkyber),
             .alu_operand_a_kyber_o (xkyber_alu_operand_a),
             .alu_operand_b_kyber_o (xkyber_alu_operand_b),
@@ -427,8 +412,8 @@ module execute
 
         logic [31:0] mul_first_operand, mul_second_operand;
 
-        assign mul_first_operand  = (XKYBEREnable && is_xkyber) ? {16'b0, mult_kyber_op_a} : rs1_data_i;
-        assign mul_second_operand = (XKYBEREnable && is_xkyber) ? {16'b0, mult_kyber_op_b} : rs2_data_i; 
+        assign mul_first_operand  = (XKYBEREnable && ctrl_i.is_kyber) ? {16'b0, mult_kyber_op_a} : rs1_data_i;
+        assign mul_second_operand = (XKYBEREnable && ctrl_i.is_kyber) ? {16'b0, mult_kyber_op_b} : rs2_data_i; 
 
         mul mul1 (
             .clk              (clk),
@@ -518,16 +503,11 @@ module execute
     logic [31:0] sha2_result;
 
     if (ZKNHEnable) begin: zknh_gen_on
-        
-        logic sha2_en;
-
-        assign sha2_en = (instruction_operation_i inside {SIG0H,SIG0L,SIG1H,SIG1L,SUM0R,SUM1R,SIG0,SIG1,SUM0,SUM1});
-
         sha2_unit #(
             .LOGIC_GATING(1'b1)
         ) u_sha2_unit (
-            .sha2_en_i(sha2_en),
-            .sha2_op_i(instruction_operation_i),
+            .sha2_en_i(ctrl_i.is_sha2),
+            .sha2_op_i(ctrl_i.sha2_op),
             .op_a_i(first_operand),
             .op_b_i(second_operand_i),
             .sha2_result_o(sha2_result)
@@ -555,7 +535,7 @@ module execute
             .reset_n                (reset_n),
             .instruction_i          (instruction_i),
             .enable_i               (ctrl_i.is_vector),
-            .vector_operation_i     (vector_operation_i),
+            .vector_operation_i     (ctrl_i.vector_op),
             .op1_scalar_i           (rs1_data_i),
             .op2_scalar_i           (rs2_data_i),
             .hold_o                 (hold_vector),
@@ -740,23 +720,9 @@ module execute
     // ZBKB Extension
     ////////////////////////////////////////////////////////////////////////////////
 
-    logic [31:0] shift_result;   
-    logic [31:0] pack_result;   
-    logic [31:0] bwlogic_result; 
-    logic [31:0] rev_result;   
-    logic [31:0] shuffle_result;    
+    logic [31:0] zbkb_result;
 
     if (ZBKBEnable) begin: zbkb_gen_on
-
-        //////////
-        // Pack //
-        //////////
-        always_comb begin
-            unique case (1'b1)
-                ctrl_i.zbkb_is_packh: pack_result = {16'h0, second_operand_i[7:0], rs1_data_i[7:0]};
-                default:              pack_result = {second_operand_i[15:0], rs1_data_i[15:0]};
-            endcase
-        end
 
         ///////////////////
         // Bitwise Logic //
@@ -772,14 +738,9 @@ module execute
         assign bwlogic_and_result = rs1_data_i & bwlogic_operand_b;
         assign bwlogic_xor_result = rs1_data_i ^ bwlogic_operand_b;
 
-        always_comb begin
-            unique case (1'b1)
-                ctrl_i.zbkb_is_orn:  bwlogic_result = bwlogic_or_result;
-                ctrl_i.zbkb_is_andn: bwlogic_result = bwlogic_and_result;
-                default:             bwlogic_result = bwlogic_xor_result;
-            endcase
-        end
-
+        /////////////////
+        // Bit reverse //
+        /////////////////
         logic [4:0] shift_amt;
         assign shift_amt[4:0] = second_operand_i[4:0];
 
@@ -787,6 +748,7 @@ module execute
         assign zbp_shift_amt[2:0] = shift_amt[2:0];
         assign zbp_shift_amt[4:3] = shift_amt[4:3];
 
+        logic [31:0] rev_result;
         always_comb begin
             rev_result = rs1_data_i;
 
@@ -816,38 +778,48 @@ module execute
             end
         end
 
+        ///////////////
+        // Zip/Unzip //
+        ///////////////
+        logic [31:0] zip_result;
+        logic [31:0] unzip_result;
         always_comb begin
-            if (ctrl_i.zbkb_is_zip) begin
-                for (int i = 0; i < 16; i++) begin
-                    shuffle_result[2*i] = rs1_data_i[i];
-                    shuffle_result[2*i + 1] = rs1_data_i[i + 16];
-                end
-            end
-
-            else begin
-                for (int i = 0; i < 16; i++) begin
-                    shuffle_result[i]   = rs1_data_i[2*i];
-                    shuffle_result[i + 16] = rs1_data_i[2*i + 1];
-                end
+            for (int i = 0; i < 16; i++) begin
+                zip_result[2*i]        = rs1_data_i[i];
+                zip_result[2*i + 1]    = rs1_data_i[i + 16];
+                unzip_result[i]        = rs1_data_i[2*i];
+                unzip_result[i + 16]   = rs1_data_i[2*i + 1];
             end
         end
 
+        ////////////
+        // Rotate //
+        ////////////
         logic [4:0] shift_amt_compl; // complementary shift amount (32 - shift_amt)
-
         assign shift_amt_compl = 5'(6'd32 - {1'b0, second_operand_i[4:0]});
 
         logic [31:0] ror_result, rol_result;
-
         assign ror_result   =  srl_result | (rs1_data_i << shift_amt_compl);
         assign rol_result   =  sll_result | (rs1_data_i >> shift_amt_compl);
-        assign shift_result = ctrl_i.zbkb_is_rol ? rol_result : ror_result;
+
+        always_comb begin
+            unique case (ctrl_i.zbkb_op)
+                ZBKBROR:   zbkb_result = ror_result;
+                ZBKBROL:   zbkb_result = rol_result;
+                ZBKBORN:   zbkb_result = bwlogic_or_result;
+                ZBKBANDN:  zbkb_result = bwlogic_and_result;
+                ZBKBXNOR:  zbkb_result = bwlogic_xor_result;
+                ZBKBREV8,
+                ZBKBBREV8: zbkb_result = rev_result;
+                ZBKBZIP:   zbkb_result = zip_result;
+                ZBKBUNZIP: zbkb_result = unzip_result;
+                ZBKBPACKH: zbkb_result = {16'h0, second_operand_i[7:0], rs1_data_i[7:0]};
+                default:   zbkb_result = {second_operand_i[15:0], rs1_data_i[15:0]};
+            endcase
+        end
     end
     else begin : gen_zbkb_off
-        assign shift_result   = '0;   
-        assign pack_result    = '0;   
-        assign bwlogic_result = '0;
-        assign rev_result     = '0;
-        assign shuffle_result = '0;    
+        assign zbkb_result = '0;
     end
 
 //////////////////////////////////////////////////////////////////////////////
@@ -856,44 +828,29 @@ module execute
 
     always_comb begin
         unique case (1'b1)
-            ctrl_i.is_csr:          result = csr_data_read_i;
-            ctrl_i.is_jal_jalr:     result = pc_next;
-            ctrl_i.is_slt:          result = {31'b0, less_than};
-            ctrl_i.is_sltu:         result = {31'b0, less_than_unsigned};
-            ctrl_i.is_xor:          result = xor_result;
-            ctrl_i.is_or:           result = or_result;
-            ctrl_i.is_and:          result = and_result;
-            ctrl_i.is_sll:          result = sll_result;
-            ctrl_i.is_srl:          result = srl_result;
-            ctrl_i.is_sra:          result = sra_result;
-            ctrl_i.is_lui:          result = second_operand_i;
-            ctrl_i.is_auipc:        result = jump_imm_target_i;
-            ctrl_i.is_div:          result = (MULEXT == MUL_M)          ? div_result                           : sum_result;
-            ctrl_i.is_rem:          result = (MULEXT == MUL_M)          ? rem_result                           : sum_result;
-            ctrl_i.is_mul:          result = (MULEXT != MUL_OFF)        ? mul_result                           : sum_result;
-            ctrl_i.is_aes:          result = ZKNEEnable                 ? aes_result                           : sum_result;
-            ctrl_i.is_vector:       result = VEnable                    ? vector_scalar_result                 : sum_result;
-            ctrl_i.is_zicond:       result = ZICONDEnable               ? result_zicond                        : sum_result;
-            ctrl_i.is_sc:           result = (AMOEXT inside {AMO_ZALRSC, AMO_A}) ? {31'h0, lrsc_result}       : sum_result;
-            ctrl_i.zbkb_is_ror:     result = ZBKBEnable                 ? shift_result                         : sum_result;
-            ctrl_i.zbkb_is_rol:     result = ZBKBEnable                 ? shift_result                         : sum_result;
-            ctrl_i.zbkb_is_orn:     result = ZBKBEnable                 ? bwlogic_result                       : sum_result;
-            ctrl_i.zbkb_is_andn:    result = ZBKBEnable                 ? bwlogic_result                       : sum_result;
-            ctrl_i.zbkb_is_rev8:    result = ZBKBEnable                 ? rev_result                           : sum_result;
-            ctrl_i.zbkb_is_brev8:   result = ZBKBEnable                 ? rev_result                           : sum_result;
-            ctrl_i.zbkb_is_zip:     result = ZBKBEnable                 ? shuffle_result                       : sum_result;
-            ctrl_i.zbkb_is_unzip:   result = ZBKBEnable                 ? shuffle_result                       : sum_result;
-            ctrl_i.zbkb_is_xnor:    result = ZBKBEnable                 ? bwlogic_result                       : sum_result;
-            ctrl_i.is_zbkb:         result = ZBKBEnable                 ? pack_result                          : sum_result;
-            default: begin
-                /* SHA2/Kyber ops set no ctrl one-hot bit, so they land here */
-                if (ZKNHEnable && instruction_operation_i inside {SIG0H, SIG0L, SIG1H, SIG1L, SUM0R, SUM1R, SIG0, SIG1, SUM0, SUM1})
-                    result = sha2_result;
-                else if (XKYBEREnable && is_xkyber)
-                    result = xkyber_result;
-                else
-                    result = sum_result;
-            end
+            ctrl_i.is_csr:                                       result = csr_data_read_i;
+            ctrl_i.is_jal_jalr:                                  result = pc_next;
+            ctrl_i.is_slt:                                       result = {31'b0, less_than};
+            ctrl_i.is_sltu:                                      result = {31'b0, less_than_unsigned};
+            ctrl_i.is_xor:                                       result = xor_result;
+            ctrl_i.is_or:                                        result = or_result;
+            ctrl_i.is_and:                                       result = and_result;
+            ctrl_i.is_sll:                                       result = sll_result;
+            ctrl_i.is_srl:                                       result = srl_result;
+            ctrl_i.is_sra:                                       result = sra_result;
+            ctrl_i.is_lui:                                       result = second_operand_i;
+            ctrl_i.is_auipc:                                     result = jump_imm_target_i;
+            (MULEXT == MUL_M && ctrl_i.is_div):                  result = div_result;
+            (MULEXT == MUL_M && ctrl_i.is_rem):                  result = rem_result;
+            (MULEXT != MUL_OFF && ctrl_i.is_mul):                result = mul_result;
+            (AMOEXT inside {AMO_ZALRSC, AMO_A} && ctrl_i.is_sc): result = {31'h0, lrsc_result};
+            (ZICONDEnable && ctrl_i.is_zicond):                  result = result_zicond;
+            (ZBKBEnable && ctrl_i.is_zbkb):                      result = zbkb_result;
+            (ZKNEEnable && ctrl_i.is_aes):                       result = aes_result;
+            (ZKNHEnable && ctrl_i.is_sha2):                      result = sha2_result;
+            (VEnable && ctrl_i.is_vector):                       result = vector_scalar_result;
+            (XKYBEREnable && ctrl_i.is_kyber):                   result = xkyber_result;
+            default:                                             result = sum_result;
         endcase
     end
 

--- a/rtl/execute.sv
+++ b/rtl/execute.sv
@@ -62,7 +62,6 @@ module execute
     input   exec_ctrl_t             ctrl_i,
     input   logic [11:0]            csr_address_i,
     input   logic [31:0]            instruction_i,
-    input   iType_e                 instruction_operation_i,
     input   iTypeVector_e           vector_operation_i,
     /* verilator lint_on UNUSEDSIGNAL */
 
@@ -555,7 +554,7 @@ module execute
             .clk                    (clk),
             .reset_n                (reset_n),
             .instruction_i          (instruction_i),
-            .instruction_operation_i(instruction_operation_i),
+            .enable_i               (ctrl_i.is_vector),
             .vector_operation_i     (vector_operation_i),
             .op1_scalar_i           (rs1_data_i),
             .op2_scalar_i           (rs2_data_i),

--- a/rtl/fetch.sv
+++ b/rtl/fetch.sv
@@ -37,7 +37,6 @@ module fetch
     input   logic           enable_i,
 
     /* Jump control */
-    input   logic           jump_i,
     input   logic           ctx_switch_i,
     input   logic           should_jump_i,
     input   logic [31:0]    jump_target_i,
@@ -45,6 +44,7 @@ module fetch
     
     /* Branch prediction */
     /* verilator lint_off UNUSEDSIGNAL */
+    input   logic           jump_i,
     input   logic           bp_take_i,
     input   logic [31:0]    bp_target_i,
     /* verilator lint_on UNUSEDSIGNAL */

--- a/rtl/fetch.sv
+++ b/rtl/fetch.sv
@@ -42,8 +42,6 @@ module fetch
     input   logic           should_jump_i,
     input   logic [31:0]    jump_target_i,
     input   logic [31:0]    ctx_switch_target_i,
-    output  logic           jumping_o,
-    output  logic           jump_misaligned_o,
     
     /* Branch prediction */
     /* verilator lint_off UNUSEDSIGNAL */
@@ -60,10 +58,9 @@ module fetch
     input   logic [31:0]    instruction_data_i,
 
     /* Fetched output */
+    output  decode_ctrl_t   ctrl_o,
     output  logic [31:0]    pc_o,
-    output  logic [31:0]    instruction_o,
-    output  logic           valid_o,
-    output  logic           compressed_o
+    output  logic [31:0]    instruction_o
 );
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -80,7 +77,7 @@ module fetch
     logic [31:0] iaddr_jumped;
 
     logic is_jumping;
-    assign is_jumping = (jumping_o && !jump_rollback_i) || jump_misaligned_o;
+    assign is_jumping = (jumping_r && !jump_rollback_i) || jump_misaligned_r;
 
     logic jump_confirmed;
     assign jump_confirmed = should_jump_i || (bp_taken_r && !jump_rollback_i);
@@ -300,13 +297,18 @@ module fetch
 // CPU Interface
 ////////////////////////////////////////////////////////////////////////////////
 
+    logic valid_r;
+    logic jumping_r;
+    logic jump_misaligned_r;
+    logic compressed;
+
     always_ff @(posedge clk or negedge reset_n) begin
         if (!reset_n)
-            valid_o <= 1'b0;
+            valid_r <= 1'b0;
         else if (sys_reset)
-            valid_o <= 1'b0;
+            valid_r <= 1'b0;
         else if (enable_i || is_jumping)
-            valid_o <= valid;
+            valid_r <= valid;
     end
 
     logic [31:0] instruction;
@@ -339,7 +341,7 @@ module fetch
             pc_o <= start_address;
         end
         else begin
-            if (jump_confirmed_r || jump_misaligned_o)
+            if (jump_confirmed_r || jump_misaligned_r)
                 pc_o <= pc_jumped;
             else if (enable_i && valid)
                 pc_o <= next_pc;
@@ -348,16 +350,16 @@ module fetch
     
     always_ff @(posedge clk or negedge reset_n) begin
         if (!reset_n) begin
-            jumping_o <= 1'b1;
+            jumping_r <= 1'b1;
         end
         else if (sys_reset) begin
-            jumping_o <= 1'b1;
+            jumping_r <= 1'b1;
         end
         else begin
             if (jumped)
-                jumping_o <= 1'b1;
+                jumping_r <= 1'b1;
             else if (valid || jump_rollback_i)
-                jumping_o <= 1'b0;
+                jumping_r <= 1'b0;
         end
     end
 
@@ -381,8 +383,6 @@ module fetch
             else if (pop && (valid_fetch || valid_buffer))
                 instruction_r <= inst_buffered;
         end
-
-        logic compressed;
         
         /* Alignment control */
         logic [31:0] instruction_built;
@@ -390,7 +390,7 @@ module fetch
             if (jump_confirmed_r)
                 /* On jump, last valid instruction is the next one */
                 instruction_built = inst_buffered;
-            else if (jump_misaligned_o || (unaligned ^ compressed))
+            else if (jump_misaligned_r || (unaligned ^ compressed))
                 /* When next instruction is unaligned we also need two fetches */
                 /* Shift the last instruction msbs and join with the next lsbs */
                 instruction_built = {inst_buffered[15:0], instruction_r[31:16]};
@@ -414,7 +414,6 @@ module fetch
             else if ((enable_i || is_jumping) && valid)
                 compressed <= next_compressed;
         end
-        assign compressed_o = compressed;
 
         /* We consider a instruction prefetched when it was removed from buffer */
         /* or read from memory but will be used again. Happens after compressed */
@@ -425,16 +424,16 @@ module fetch
         /* Only after the first needed fetch is valid the signal is deasserted */
         always_ff @(posedge clk or negedge reset_n) begin
             if (!reset_n) begin
-                jump_misaligned_o <= 1'b0;
+                jump_misaligned_r <= 1'b0;
             end
             else if (sys_reset) begin
-                jump_misaligned_o <= 1'b0;
+                jump_misaligned_r <= 1'b0;
             end
             else begin
                 if (jump_confirmed_r)
-                    jump_misaligned_o <= pc_jumped[1];
-                else if (!jumping_o && valid)
-                    jump_misaligned_o <= 1'b0;
+                    jump_misaligned_r <= pc_jumped[1];
+                else if (!jumping_r && valid)
+                    jump_misaligned_r <= 1'b0;
             end
         end
 
@@ -449,13 +448,19 @@ module fetch
         );
 
         assign instruction = next_compressed ? instruction_decompressed : instruction_built;
-        assign next_pc     = pc_o + (compressed_o ? 32'd2 : 32'd4);
+        assign next_pc     = pc_o + (compressed ? 32'd2 : 32'd4);
     end
     else begin : gen_compressed_off
         assign instruction_prefetched = 1'b0;
-        assign compressed_o           = 1'b0;
+        assign compressed             = 1'b0;
         assign next_pc                = pc_o + 32'd4;
         assign instruction            = inst_buffered;
-        assign jump_misaligned_o      = 1'b0;
+        assign jump_misaligned_r      = 1'b0;
     end
+
+    assign ctrl_o.valid           = valid_r;
+    assign ctrl_o.compressed      = compressed;
+    assign ctrl_o.jumping         = jumping_r;
+    assign ctrl_o.jump_misaligned = jump_misaligned_r;
+
 endmodule

--- a/rtl/fetch.sv
+++ b/rtl/fetch.sv
@@ -76,6 +76,9 @@ module fetch
     logic bp_taken_r;
     logic [31:0] iaddr_jumped;
 
+    logic jumping_r;
+    logic jump_misaligned_r;
+
     logic is_jumping;
     assign is_jumping = (jumping_r && !jump_rollback_i) || jump_misaligned_r;
 
@@ -298,8 +301,6 @@ module fetch
 ////////////////////////////////////////////////////////////////////////////////
 
     logic valid_r;
-    logic jumping_r;
-    logic jump_misaligned_r;
     logic compressed;
 
     always_ff @(posedge clk or negedge reset_n) begin

--- a/rtl/mem_access.sv
+++ b/rtl/mem_access.sv
@@ -1,0 +1,51 @@
+`include "RS5_pkg.sv"
+
+module mem_access
+    import RS5_pkg::*;
+(
+    input  logic        clk,
+    input  logic        reset_n,
+    input  logic        stall,
+
+    /* Registered input from execute */
+    input  wb_ctrl_t    ctrl_i,
+    input  logic [31:0] result_i,
+    input  logic  [4:0] rd_i,
+
+    /* MMU interface */
+    input  logic        load_access_fault_i,
+
+    /* Registered outputs to retire */
+    output wb_ctrl_t    ctrl_o,
+    output logic [31:0] result_o,
+    output logic  [4:0] rd_o
+);
+
+    always_ff @(posedge clk or negedge reset_n) begin
+        if (!reset_n)
+            ctrl_o <= '0;
+        else if (!stall) begin
+            ctrl_o        <= ctrl_i;
+            ctrl_o.rd_we  <= ctrl_i.rd_we && !load_access_fault_i;
+        end
+    end
+
+    always_ff @(posedge clk or negedge reset_n) begin
+        if (!reset_n) begin
+            rd_o <= '0;
+        end
+        else if (!stall) begin
+            rd_o <= rd_i;
+        end
+    end
+
+    always_ff @(posedge clk or negedge reset_n) begin
+        if (!reset_n) begin
+            result_o <= '0;
+        end
+        else if (!stall) begin
+            result_o <= result_i;
+        end
+    end
+
+endmodule

--- a/rtl/retire.sv
+++ b/rtl/retire.sv
@@ -34,15 +34,20 @@ module retire
     /* verilator lint_off UNUSEDSIGNAL */
     input   logic           clk,
     input   logic           reset_n,
-    input   logic           regbank_we_i,
     /* verilator lint_on UNUSEDSIGNAL */
 
-    input   iType_e         instruction_operation_i,
+    /* Registered input from mem_access */
+    input   wb_ctrl_t       ctrl_i,
     input   logic [31:0]    result_i,
+
+    /* Memory interface */
     input   logic [31:0]    mem_data_i,
 
-    output  logic [31:0]    reservation_data_o,
-    output  logic [31:0]    regbank_data_o
+    /* Regbank interface */
+    output  logic [31:0]    regbank_data_o,
+
+    /* Registered output to execute */
+    output  logic [31:0]    reservation_data_o
 );
 
     logic [31:0]    memory_data;
@@ -51,62 +56,29 @@ module retire
 // Memory Signal Generation
 //////////////////////////////////////////////////////////////////////////////
 
+    logic [7:0]  byte_data;
+    logic        byte_sign;
+    logic [15:0] half_data;
+    logic        half_sign;
+
     always_comb begin
-        unique case (instruction_operation_i)
-            LB: begin
-                case (result_i[1:0])
-                    2'b11: begin
-                        memory_data[31:8] = {24{mem_data_i[31]}};
-                        memory_data[7:0]  = mem_data_i[31:24];
-                    end
-                    2'b10: begin
-                        memory_data[31:8] = {24{mem_data_i[23]}};
-                        memory_data[7:0]  = mem_data_i[23:16];
-                    end
-                    2'b01: begin
-                        memory_data[31:8] = {24{mem_data_i[15]}};
-                        memory_data[7:0]  = mem_data_i[15:8];
-                    end
-                    default: begin
-                        memory_data[31:8] = {24{mem_data_i[7]}};
-                        memory_data[7:0]  = mem_data_i[7:0];
-                    end
-                endcase
-            end
+        case (result_i[1:0])
+            2'b11:   byte_data = mem_data_i[31:24];
+            2'b10:   byte_data = mem_data_i[23:16];
+            2'b01:   byte_data = mem_data_i[15:8];
+            default: byte_data = mem_data_i[7:0];
+        endcase
+        byte_sign = ctrl_i.is_unsigned ? 1'b0 : byte_data[7];
 
-            LBU: begin
-                memory_data[31:8] = '0;
-                case (result_i[1:0])
-                    2'b11:   memory_data[7:0]  = mem_data_i[31:24];
-                    2'b10:   memory_data[7:0]  = mem_data_i[23:16];
-                    2'b01:   memory_data[7:0]  = mem_data_i[15:8];
-                    default: memory_data[7:0]  = mem_data_i[7:0];
-                endcase
-            end
+        half_data = result_i[1] ? mem_data_i[31:16] : mem_data_i[15:0];
+        half_sign = ctrl_i.is_unsigned ? 1'b0 : half_data[15];
+    end
 
-            LH: begin
-                case (result_i[1])
-                    1'b1: begin
-                        memory_data[31:16] = {16{mem_data_i[31]}};
-                        memory_data[15:0]  = mem_data_i[31:16];
-                    end
-                    default: begin
-                        memory_data[31:16] = {16{mem_data_i[15]}};
-                        memory_data[15:0]  = mem_data_i[15:0];
-                    end
-                endcase
-            end
-
-            LHU: begin
-                memory_data[31:16] = '0;
-                case (result_i[1])
-                    1'b1:    memory_data[15:0] = mem_data_i[31:16];
-                    default: memory_data[15:0] = mem_data_i[15:0];
-                endcase
-            end
-
-            // LW, LR_W
-            default: memory_data = mem_data_i;
+    always_comb begin
+        unique case (1'b1)
+            ctrl_i.is_byte: memory_data = {{24{byte_sign}}, byte_data};
+            ctrl_i.is_half: memory_data = {{16{half_sign}}, half_data};
+            default:        memory_data = mem_data_i;
         endcase
     end
 
@@ -114,12 +86,7 @@ module retire
 // Assign to Register Bank Write Back
 //////////////////////////////////////////////////////////////////////////////
 
-    always_comb begin
-        unique case (instruction_operation_i)
-            LB,LBU,LH,LHU,LW,LR_W: regbank_data_o = memory_data;
-            default:               regbank_data_o = result_i;
-        endcase
-    end
+    assign regbank_data_o = (ctrl_i.is_load || ctrl_i.is_lr) ? memory_data : result_i;
 
 ////////////////////////////////////////////////////////////////////////////////
 // LR/SC registers
@@ -130,10 +97,10 @@ module retire
             if (!reset_n) begin
                 reservation_data_o <= '0;
             end
-            else if (regbank_we_i) begin    /* Avoid writing on MMU exceptions */
-                unique case (instruction_operation_i)
-                    LR_W:    reservation_data_o <= mem_data_i;
-                    SC_W:    reservation_data_o <= '0;
+            else if (ctrl_i.rd_we) begin    /* Avoid writing on MMU exceptions */
+                unique case (1'b1)
+                    ctrl_i.is_lr: reservation_data_o <= mem_data_i;
+                    ctrl_i.is_sc: reservation_data_o <= '0;
                     default: ;
                 endcase
             end

--- a/rtl/rtl.f
+++ b/rtl/rtl.f
@@ -32,6 +32,7 @@
 ./xkyber.sv
 ./plic.sv
 ./regbank.sv
+./mem_access.sv
 ./retire.sv
 ./RS5_pkg.sv
 ./RS5.sv

--- a/rtl/sha2_unit.sv
+++ b/rtl/sha2_unit.sv
@@ -23,8 +23,8 @@ module sha2_unit
     parameter LOGIC_GATING = 1  // Gate sub-module inputs to save toggling
 )
 (
-    input  logic       sha2_en_i,
-    input  iType_e     sha2_op_i,
+    input  logic        sha2_en_i,
+    input  iTypeSha2_e  sha2_op_i,
 
     input  logic[31:0] op_a_i,
     input  logic[31:0] op_b_i,
@@ -40,18 +40,18 @@ module sha2_unit
     always_comb begin
         unique case (sha2_op_i)
             // SHA256 instructions
-            SIG0: sha2_result_o = `ROTR(op_a_gated, 7) ^ `ROTR(op_a_gated, 18) ^ (op_a_gated >> 3);
-            SIG1: sha2_result_o = `ROTR(op_a_gated, 17) ^ `ROTR(op_a_gated, 19) ^ (op_a_gated >> 10);
-            SUM0: sha2_result_o = `ROTR(op_a_gated, 2) ^ `ROTR(op_a_gated, 13) ^ `ROTR(op_a_gated, 22);
-            SUM1: sha2_result_o = `ROTR(op_a_gated, 6) ^ `ROTR(op_a_gated, 11) ^ `ROTR(op_a_gated, 25);
+            SHA2SIG0: sha2_result_o = `ROTR(op_a_gated, 7) ^ `ROTR(op_a_gated, 18) ^ (op_a_gated >> 3);
+            SHA2SIG1: sha2_result_o = `ROTR(op_a_gated, 17) ^ `ROTR(op_a_gated, 19) ^ (op_a_gated >> 10);
+            SHA2SUM0: sha2_result_o = `ROTR(op_a_gated, 2) ^ `ROTR(op_a_gated, 13) ^ `ROTR(op_a_gated, 22);
+            SHA2SUM1: sha2_result_o = `ROTR(op_a_gated, 6) ^ `ROTR(op_a_gated, 11) ^ `ROTR(op_a_gated, 25);
 
             // SHA512 instructions
-            SIG0H: sha2_result_o = (op_a_gated >> 1) ^ (op_a_gated >> 7) ^ (op_a_gated >> 8) ^ (op_b_gated << 31) ^ (op_b_gated << 24);
-            SIG0L: sha2_result_o = (op_a_gated >> 1) ^ (op_a_gated >> 7) ^ (op_a_gated >> 8) ^ (op_b_gated << 31) ^ (op_b_gated << 25) ^ (op_b_gated << 24);
-            SIG1H: sha2_result_o = (op_a_gated << 3) ^ (op_a_gated >> 6) ^ (op_a_gated >> 19) ^ (op_b_gated >> 29) ^ (op_b_gated << 13);
-            SIG1L: sha2_result_o = (op_a_gated << 3) ^ (op_a_gated >> 6) ^ (op_a_gated >> 19) ^ (op_b_gated >> 29) ^ (op_b_gated << 26) ^ (op_b_gated << 13);
-            SUM0R: sha2_result_o = (op_a_gated << 25) ^ (op_a_gated << 30) ^ (op_a_gated >> 28) ^ (op_b_gated >> 7) ^ (op_b_gated >> 2) ^ (op_b_gated << 4);
-            SUM1R: sha2_result_o = (op_a_gated << 23) ^ (op_a_gated >> 14) ^ (op_a_gated >> 18) ^ (op_b_gated >> 9) ^ (op_b_gated << 18) ^ (op_b_gated << 14);
+            SHA2SIG0H: sha2_result_o = (op_a_gated >> 1) ^ (op_a_gated >> 7) ^ (op_a_gated >> 8) ^ (op_b_gated << 31) ^ (op_b_gated << 24);
+            SHA2SIG0L: sha2_result_o = (op_a_gated >> 1) ^ (op_a_gated >> 7) ^ (op_a_gated >> 8) ^ (op_b_gated << 31) ^ (op_b_gated << 25) ^ (op_b_gated << 24);
+            SHA2SIG1H: sha2_result_o = (op_a_gated << 3) ^ (op_a_gated >> 6) ^ (op_a_gated >> 19) ^ (op_b_gated >> 29) ^ (op_b_gated << 13);
+            SHA2SIG1L: sha2_result_o = (op_a_gated << 3) ^ (op_a_gated >> 6) ^ (op_a_gated >> 19) ^ (op_b_gated >> 29) ^ (op_b_gated << 26) ^ (op_b_gated << 13);
+            SHA2SUM0R: sha2_result_o = (op_a_gated << 25) ^ (op_a_gated << 30) ^ (op_a_gated >> 28) ^ (op_b_gated >> 7) ^ (op_b_gated >> 2) ^ (op_b_gated << 4);
+            SHA2SUM1R: sha2_result_o = (op_a_gated << 23) ^ (op_a_gated >> 14) ^ (op_a_gated >> 18) ^ (op_b_gated >> 9) ^ (op_b_gated << 18) ^ (op_b_gated << 14);
 
             default: sha2_result_o = `ROTR(op_a_gated, 7) ^ `ROTR(op_a_gated, 18) ^ (op_a_gated >> 3);
         endcase

--- a/rtl/vector/vectorCSRs.sv
+++ b/rtl/vector/vectorCSRs.sv
@@ -22,7 +22,7 @@ module vectorCSRs
     input   logic                   clk,
     input   logic                   reset_n,
 
-    input   iType_e                 instruction_operation_i,
+    input   logic                   is_vector_op_i,
     input   iTypeVector_e           vector_operation_i,
     input   logic [31:0]            op1_scalar_i,
     /* verilator lint_off UNUSEDSIGNAL */
@@ -123,7 +123,7 @@ module vectorCSRs
             vlmul       <= LMUL_1;
             vl          <= '0;
         end
-        else if (instruction_operation_i == VECTOR && vector_operation_i inside {VSETVL, VSETVLI, VSETIVLI}) begin
+        else if (is_vector_op_i && vector_operation_i inside {VSETVL, VSETVLI, VSETIVLI}) begin
             cfg_error_r <= cfg_error;
             vill        <= vill_next | cfg_error;
             vma         <= vma_next;

--- a/rtl/vector/vectorLSU.sv
+++ b/rtl/vector/vectorLSU.sv
@@ -34,7 +34,8 @@ module vectorLSU
     input  vector_states_e            current_state,
     input  logic                      hazard_detected_i,
 
-    input  iType_e                    instruction_operation_i,
+    input  logic                      is_vload_i,
+    input  logic                      is_vstore_i,
     input  logic                      whole_reg_load_store,
     input  vlmul_e                    vlmul,
 
@@ -142,7 +143,7 @@ module vectorLSU
     always_comb begin
         unique case (state)
             VLSU_IDLE:
-                if (instruction_operation_i inside {VLOAD, VSTORE} && current_state == V_IDLE && !hazard_detected_i)
+                if ((is_vload_i || is_vstore_i) && current_state == V_IDLE && !hazard_detected_i)
                     next_state = VLSU_FIRST_CYCLE;
                 else
                     next_state = VLSU_IDLE;
@@ -653,7 +654,7 @@ module vectorLSU
 // Output Control
 //////////////////////////////////////////////////////////////////////////////
 
-    assign hold_o = (instruction_operation_i == VSTORE)
+    assign hold_o = (is_vstore_i)
                     ? (state inside {VLSU_FIRST_CYCLE, VLSU_EXEC, VLSU_LAST_CYCLE})
                     : ((state == VLSU_FIRST_CYCLE && state_r == VLSU_IDLE) || (state_r inside {VLSU_FIRST_CYCLE, VLSU_EXEC, VLSU_LAST_CYCLE}));
 
@@ -662,7 +663,7 @@ module vectorLSU
     assign mem_write_data_o   = write_data << shift_amount;
 
     always_comb begin
-        if (instruction_operation_i == VSTORE) begin
+        if (is_vstore_i) begin
             if (addrMode == UNIT_STRIDED)
                 mem_write_enable_o = (state inside{VLSU_FIRST_CYCLE, VLSU_EXEC, VLSU_LAST_CYCLE})
                                     ? mem_write_enable

--- a/rtl/vectorUnit.sv
+++ b/rtl/vectorUnit.sv
@@ -26,7 +26,7 @@ module vectorUnit
     input   logic                  reset_n,
 
     input   logic [31:0]           instruction_i,
-    input   iType_e                instruction_operation_i,
+    input   logic                  enable_i,
     input   iTypeVector_e          vector_operation_i,
 
     input   logic [31:0]           op1_scalar_i,
@@ -54,6 +54,7 @@ module vectorUnit
     logic [10:0] zimm;
     logic        vm;
     opCat_e      opCat;
+    logic        op_vector, op_vload, op_vstore;
     logic        accumulate_instruction;
     logic        mask_instruction;
     logic        multiply_instruction;
@@ -107,12 +108,16 @@ module vectorUnit
     assign zimm     = {instruction_i[30:20]};
     assign opCat    = opCat_e'(instruction_i[14:12]);
 
+    assign op_vload  = enable_i && (vector_operation_i == VLD);
+    assign op_vstore = enable_i && (vector_operation_i == VST);
+    assign op_vector = enable_i && !(vector_operation_i == VLD) && !(vector_operation_i == VST);
+
     assign accumulate_instruction = (vector_operation_i inside {VMACC, VNMSAC, VMADD, VNMSUB});
     assign multiply_instruction   = (vector_operation_i inside {VMUL, VMULH, VMULHSU, VMULHU} | accumulate_instruction | widening_instruction);
     assign reduction_instruction  = (vector_operation_i inside {VREDSUM, VREDMAXU, VREDMAX, VREDMINU, VREDMIN, VREDAND, VREDOR, VREDXOR});
     assign widening_instruction   = (vector_operation_i inside {VWMUL, VWMULU, VWMULSU});
-    assign whole_reg_load_store   = (instruction_i[24:20] == 5'b01000 && instruction_operation_i inside {VLOAD, VSTORE} && instruction_i[27:26] == 2'b00);
-    assign mask_load_store        = (instruction_i[24:20] == 5'b01011 && instruction_operation_i inside {VLOAD, VSTORE} && instruction_i[27:26] == 2'b00);
+    assign whole_reg_load_store   = (instruction_i[24:20] == 5'b01000 && (op_vload || op_vstore) && instruction_i[27:26] == 2'b00);
+    assign mask_load_store        = (instruction_i[24:20] == 5'b01011 && (op_vload || op_vstore) && instruction_i[27:26] == 2'b00);
     assign mask_instruction       = (vector_operation_i inside {VMSEQ, VMSNE, VMSLTU, VMSLT, VMSLEU, VMSLE, VMSGTU, VMSGT});
 
     assign elements_per_reg = VLENB >> vsew;
@@ -151,7 +156,7 @@ module vectorUnit
     ) vectorCSRs1 (
         .clk                    (clk),
         .reset_n                (reset_n),
-        .instruction_operation_i(instruction_operation_i),
+        .is_vector_op_i         (enable_i),
         .vector_operation_i     (vector_operation_i),
         .op1_scalar_i           (op1_scalar_i),
         .op2_scalar_i           (op2_scalar_i),
@@ -188,7 +193,7 @@ module vectorUnit
 
     assign hazard_detected = (state == V_IDLE && |write_enable == 1'b1 && (vs1_addr == vd_addr_r || vs2_addr == vd_addr_r));
 
-    assign hold_o = (instruction_operation_i inside {VECTOR, VLOAD, VSTORE}) && (next_state == V_EXEC || hazard_detected == 1'b1);
+    assign hold_o = enable_i && (next_state == V_EXEC || hazard_detected == 1'b1);
 
     always_ff @(posedge clk or negedge reset_n) begin
         if (!reset_n) begin
@@ -203,8 +208,8 @@ module vectorUnit
         unique case (state)
             V_IDLE:
                 if ((
-                    (instruction_operation_i == VECTOR && !(vector_operation_i inside {VNOP, VSETVL, VSETVLI, VSETIVLI}))
-                ||  (instruction_operation_i inside {VLOAD, VSTORE})
+                    (op_vector && !(vector_operation_i inside {VNOP, VSETVL, VSETVLI, VSETIVLI}))
+                ||  (op_vload || op_vstore)
                 ) && !hazard_detected)
                     next_state = V_EXEC;
                 else
@@ -354,7 +359,7 @@ module vectorUnit
         else if (!hold)
             total_elements_processed <= total_elements_processed + elements_per_reg;
 
-    assign vector_process_done = (total_elements_processed >= vl && !whole_reg_load_store && instruction_operation_i == VECTOR);
+    assign vector_process_done = (total_elements_processed >= vl && !whole_reg_load_store && op_vector);
 
 //////////////////////////////////////////////////////////////////////////////
 // Register Bank
@@ -367,7 +372,7 @@ module vectorUnit
 
     always_comb begin
         // VS1 Address
-        if (instruction_operation_i == VSTORE) begin
+        if (op_vstore) begin
             vs1_addr = rd_addr;
         end
         else if (vector_operation_i inside {VSLIDE1UP, VSLIDE1DOWN}) begin
@@ -415,7 +420,7 @@ module vectorUnit
         if (!reset_n) begin
             write_enable <= '0;
         end
-        else if ((state == V_EXEC) && (!hold || hold_widening) && instruction_operation_i != VSTORE && vector_operation_i != VMVXS) begin
+        else if ((state == V_EXEC) && (!hold || hold_widening) && !op_vstore && vector_operation_i != VMVXS) begin
             if (reduction_instruction || vector_operation_i == VMVSX) begin
                 unique case (vsew_effective)
                     EW8:     write_enable <= {'0, 1'b1};
@@ -531,10 +536,10 @@ module vectorUnit
             second_operand <= '0;
         end
         else if (!hold) begin
-            if (instruction_operation_i == VSTORE) begin
+            if (op_vstore) begin
                 second_operand <= vs1_data;
             end
-            else if (instruction_operation_i == VECTOR && vector_operation_i inside {VSLIDE1UP, VSLIDE1DOWN}) begin
+            else if (op_vector && vector_operation_i inside {VSLIDE1UP, VSLIDE1DOWN}) begin
                 second_operand <= vs1_data;
             end
             else begin
@@ -565,7 +570,8 @@ module vectorUnit
         .write_data_i           (second_operand),
         .current_state          (state),
         .hazard_detected_i      (hazard_detected),
-        .instruction_operation_i(instruction_operation_i),
+        .is_vload_i             (op_vload),
+        .is_vstore_i            (op_vstore),
         .whole_reg_load_store   (whole_reg_load_store),
         .vlmul                  (vlmul_effective),
         .cycle_count_r          (cycle_count_r),
@@ -633,22 +639,22 @@ module vectorUnit
 // Result Demux
 //////////////////////////////////////////////////////////////////////////////
 
-    iType_e instruction_operation_r;
+    logic   op_vload_r;
     logic   mask_instruction_r;
 
     always_ff @(posedge clk or negedge reset_n) begin
         if (!reset_n) begin
-            instruction_operation_r <= NOP;
-            mask_instruction_r      <= '0;
+            op_vload_r         <= 1'b0;
+            mask_instruction_r <= '0;
         end
         else begin
-            instruction_operation_r <= instruction_operation_i;
-            mask_instruction_r      <= mask_instruction;
+            op_vload_r         <= op_vload;
+            mask_instruction_r <= mask_instruction;
         end
     end
 
     always_comb begin
-        if (instruction_operation_r == VLOAD)
+        if (op_vload_r)
             result = result_lsu;
         else if (mask_instruction_r)
             result = result_alu_mask;

--- a/rtl/xkyber.sv
+++ b/rtl/xkyber.sv
@@ -23,7 +23,7 @@ module xkyber
 
     input   logic  [3:0]  kyber_compress_bits_i,
 
-    input   iType_e      operator_i,
+    input   iTypeKyber_e operator_i,
 
     input   logic [31:0] first_operand_i,
     input   logic [31:0] second_operand_i,
@@ -124,9 +124,9 @@ module xkyber
 
     // Conditionally subtract Q = 3329 from ALU output when performing modular addition or last step of Barrett reduction in modular multiplication
     // Subtraction is performed by adding the two's complement of 3329 (op_a + (op_b = !13'd3329) + (carry_in = 1'b1))
-    assign adjust_adder_op_b_inv = (operator_i == KYBER_ADD || operator_i == KYBER_MUL);
+    assign adjust_adder_op_b_inv = (operator_i == KYBADD || operator_i == KYBMUL);
 
-    assign adjust_adder_high_op_a = (operator_i inside {KYBER_CBD2, KYBER_CBD3}) ? {{10{alu_cbd_high_reg[2]}}, alu_cbd_high_reg} : (operator_i == KYBER_MUL) ? alu_adder_i_reg[28:16] : alu_adder_i_reg[28:16];
+    assign adjust_adder_high_op_a = (operator_i inside {KYBCBD2, KYBCBD3}) ? {{10{alu_cbd_high_reg[2]}}, alu_cbd_high_reg} : (operator_i == KYBMUL) ? alu_adder_i_reg[28:16] : alu_adder_i_reg[28:16];
     assign adjust_adder_high_op_b = adjust_adder_op_b_inv ? (13'd3329 ^ {13{1'b1}}) : 13'd3329;
     assign adjust_adder_high_carry_in = adjust_adder_op_b_inv;
     assign adjust_adder_high = adjust_adder_high_op_a + adjust_adder_high_op_b + 13'(adjust_adder_high_carry_in);
@@ -138,14 +138,14 @@ module xkyber
     always_comb begin
 
       unique case (1'b1)
-        // (operator_i == KYBER_ADD):  adjust_result_high_mux_sel = alu_adder_i[28] | !adjust_adder_high[12];
-        (operator_i == KYBER_ADD):  adjust_result_high_mux_sel = !adjust_adder_high[12];
-        // (operator_i == KYBER_SUB):  adjust_result_high_mux_sel = adjust_adder_high[12];
-        (operator_i == KYBER_SUB):  adjust_result_high_mux_sel = !alu_adder_i_reg[28];
-        // (operator_i == KYBER_CBD2): adjust_result_high_mux_sel = adjust_adder_high[12];
-        (operator_i == KYBER_CBD2): adjust_result_high_mux_sel = alu_cbd_high_reg[2];
-        // (operator_i == KYBER_CBD3): adjust_result_high_mux_sel = adjust_adder_high[12];
-        (operator_i == KYBER_CBD3): adjust_result_high_mux_sel = alu_cbd_high_reg[2];
+        // (operator_i == KYBADD):  adjust_result_high_mux_sel = alu_adder_i[28] | !adjust_adder_high[12];
+        (operator_i == KYBADD):  adjust_result_high_mux_sel = !adjust_adder_high[12];
+        // (operator_i == KYBSUB):  adjust_result_high_mux_sel = adjust_adder_high[12];
+        (operator_i == KYBSUB):  adjust_result_high_mux_sel = !alu_adder_i_reg[28];
+        // (operator_i == KYBCBD2): adjust_result_high_mux_sel = adjust_adder_high[12];
+        (operator_i == KYBCBD2): adjust_result_high_mux_sel = alu_cbd_high_reg[2];
+        // (operator_i == KYBCBD3): adjust_result_high_mux_sel = adjust_adder_high[12];
+        (operator_i == KYBCBD3): adjust_result_high_mux_sel = alu_cbd_high_reg[2];
         default:                            adjust_result_high_mux_sel = 1'b0;
 
       endcase
@@ -170,13 +170,13 @@ module xkyber
 
     end
 
-    assign adjust_adder_low_op_a = (operator_i == KYBER_COMPRESS)               ? {1'b0, alu_adder_compress_shifted_reg[12:1]} :
-                                   (operator_i inside {KYBER_CBD2, KYBER_CBD3}) ? {{10{alu_cbd_low_reg[2]}}, alu_cbd_low_reg} :
-                                   (operator_i == KYBER_MUL)                    ? alu_adder_i_reg[12:0] : alu_adder_i_reg[12:0];
+    assign adjust_adder_low_op_a = (operator_i == KYBCOMPRESS)               ? {1'b0, alu_adder_compress_shifted_reg[12:1]} :
+                                   (operator_i inside {KYBCBD2, KYBCBD3}) ? {{10{alu_cbd_low_reg[2]}}, alu_cbd_low_reg} :
+                                   (operator_i == KYBMUL)                    ? alu_adder_i_reg[12:0] : alu_adder_i_reg[12:0];
 
-    // assign adjust_adder_low_op_b = (operator_i == KYBER_COMPRESS) ? 13'd0 : (adjust_adder_op_b_inv ? !(13'd3329): 13'd3329);
-    assign adjust_adder_low_op_b = (operator_i == KYBER_COMPRESS) ? 13'd0 : (adjust_adder_op_b_inv ? (13'd3329 ^ {13{1'b1}}): 13'd3329);
-    assign adjust_adder_low_carry_in = (operator_i == KYBER_COMPRESS) ? compress_carry_in : adjust_adder_op_b_inv;
+    // assign adjust_adder_low_op_b = (operator_i == KYBCOMPRESS) ? 13'd0 : (adjust_adder_op_b_inv ? !(13'd3329): 13'd3329);
+    assign adjust_adder_low_op_b = (operator_i == KYBCOMPRESS) ? 13'd0 : (adjust_adder_op_b_inv ? (13'd3329 ^ {13{1'b1}}): 13'd3329);
+    assign adjust_adder_low_carry_in = (operator_i == KYBCOMPRESS) ? compress_carry_in : adjust_adder_op_b_inv;
     assign adjust_adder_low = (adjust_adder_low_op_a + adjust_adder_low_op_b + 13'(adjust_adder_low_carry_in));
 
     // Select "adjust_adder" when:
@@ -188,16 +188,16 @@ module xkyber
     always_comb begin
 
       unique case (1'b1)
-        // (operator_i == KYBER_ADD):    adjust_result_low_mux_sel = alu_adder_i[12] | !adjust_adder_low[12];
-        (operator_i == KYBER_ADD):    adjust_result_low_mux_sel = !adjust_adder_low[12];
-        // (operator_i == KYBER_SUB):    adjust_result_low_mux_sel = adjust_adder_low[12];
-        (operator_i == KYBER_SUB):    adjust_result_low_mux_sel = !alu_adder_i_reg[12];
-        // (operator_i == KYBER_CBD2):   adjust_result_low_mux_sel = adjust_adder_low[12];
-        (operator_i == KYBER_CBD2):   adjust_result_low_mux_sel = alu_cbd_low_reg[2];
-        // (operator_i == KYBER_CBD3):   adjust_result_low_mux_sel = adjust_adder_low[12];
-        (operator_i == KYBER_CBD3):   adjust_result_low_mux_sel = alu_cbd_low_reg[2];
-        (operator_i == KYBER_MUL):      adjust_result_low_mux_sel = !adjust_adder_low[12];
-        (operator_i == KYBER_COMPRESS): adjust_result_low_mux_sel = 1'b1;
+        // (operator_i == KYBADD):    adjust_result_low_mux_sel = alu_adder_i[12] | !adjust_adder_low[12];
+        (operator_i == KYBADD):    adjust_result_low_mux_sel = !adjust_adder_low[12];
+        // (operator_i == KYBSUB):    adjust_result_low_mux_sel = adjust_adder_low[12];
+        (operator_i == KYBSUB):    adjust_result_low_mux_sel = !alu_adder_i_reg[12];
+        // (operator_i == KYBCBD2):   adjust_result_low_mux_sel = adjust_adder_low[12];
+        (operator_i == KYBCBD2):   adjust_result_low_mux_sel = alu_cbd_low_reg[2];
+        // (operator_i == KYBCBD3):   adjust_result_low_mux_sel = adjust_adder_low[12];
+        (operator_i == KYBCBD3):   adjust_result_low_mux_sel = alu_cbd_low_reg[2];
+        (operator_i == KYBMUL):      adjust_result_low_mux_sel = !adjust_adder_low[12];
+        (operator_i == KYBCOMPRESS): adjust_result_low_mux_sel = 1'b1;
         default:                              adjust_result_low_mux_sel = 1'b0;
 
       endcase
@@ -236,11 +236,11 @@ module xkyber
     always_comb begin
         if(is_xkyber_i) begin
             unique case (operator_i)
-                KYBER_MUL: 
+                KYBMUL: 
                     stage = L1_STAGE0_WAIT;
-                KYBER_COMPRESS: 
+                KYBCOMPRESS: 
                     stage = COMPRESS_STAGE0;
-                KYBER_ADD, KYBER_SUB, KYBER_CBD2, KYBER_CBD3: 
+                KYBADD, KYBSUB, KYBCBD2, KYBCBD3: 
                     stage = FINAL_STAGE_SUB_CBD_SUM_STAGE0;
                 default: 
                     stage = IDLE;
@@ -252,7 +252,7 @@ module xkyber
 
     logic is_compress;
 
-    assign is_compress = (operator_i == KYBER_COMPRESS);
+    assign is_compress = (operator_i == KYBCOMPRESS);
 
 
     always_comb begin
@@ -290,55 +290,6 @@ module xkyber
     logic xkyber_valid;
 
     assign hold_o = is_xkyber_i && !xkyber_valid;
-
-    // synthesis translate_off
-
-    /*localparam string OUTPUT_FILE = "./result_kyber/Output.txt";
-    integer fd; 
-
-    initial begin
-
-        fd = $fopen(OUTPUT_FILE, "w");
-        
-        if (fd == 0) begin
-            $display("ERRO FATAL: Não foi possível criar o arquivo %s. Verifique se a pasta existe!", OUTPUT_FILE);
-            $finish;
-        end
-    end
-
-    
-    always_ff @(posedge clk) begin
-
-       
-        if (xkyber_valid) begin 
-            if (operator_i == KYBER_MUL)
-                $fdisplay(fd, "[CHECKER] KYBER_MUL      0x%0h e 0x%0h = 0x%0h", first_operand_i, second_operand_i, result_o);
-            else if (operator_i == KYBER_COMPRESS)
-                $fdisplay(fd, "[CHECKER] KYBER_COMPRESS 0x%0h e 0x%0h = 0x%0h", first_operand_i, second_operand_i, result_o);
-        end 
-        
-        
-        else if (operator_i inside {KYBER_ADD, KYBER_SUB, KYBER_CBD2, KYBER_CBD3}) begin 
-            case (operator_i)
-                KYBER_ADD:  $fdisplay(fd, "[CHECKER] KYBER_ADD      0x%0h e 0x%0h = 0x%0h", first_operand_i, second_operand_i, result_o);
-                KYBER_SUB:  $fdisplay(fd, "[CHECKER] KYBER_SUB      0x%0h e 0x%0h = 0x%0h", first_operand_i, second_operand_i, result_o);
-                KYBER_CBD2: $fdisplay(fd, "[CHECKER] KYBER_CBD2     0x%0h e 0x%0h = 0x%0h", first_operand_i, second_operand_i, result_o);
-                KYBER_CBD3: $fdisplay(fd, "[CHECKER] KYBER_CBD3     0x%0h e 0x%0h = 0x%0h", first_operand_i, second_operand_i, result_o);
-                default: ;
-            endcase
-        end
-
-    end
-
-    
-    final begin
-        if (fd != 0) begin
-            $fclose(fd);
-            $display("Log de saída salvo com sucesso em: %s", OUTPUT_FILE);
-        end
-    end*/
-
-    // synthesis translate_on
 
     logic [31:0] result_xkyber;
 
@@ -411,9 +362,9 @@ module xkyber
     always_comb begin 
         alu_operand_a_kyber = first_operand_i;
         alu_operand_b_kyber = second_operand_i;
-        if(operator_i == KYBER_SUB) begin 
+        if(operator_i == KYBSUB) begin 
             alu_operand_b_kyber = second_value_sub;
-        end else if(operator_i == KYBER_MUL || operator_i == KYBER_COMPRESS) begin
+        end else if(operator_i == KYBMUL || operator_i == KYBCOMPRESS) begin
             alu_operand_a_kyber = alu_operand_a_kyber_mul;
             alu_operand_b_kyber = alu_operand_b_kyber_mul;
         end


### PR DESCRIPTION
This PR reworks all pipeline signals.
It groups them into *_ctrl_t types to improve readability.
The biggest change is in the decoder, which no longer registers instruction_operation_o, which was used by absolutely everything in the execute stage, causing a huge fanout (~119) and therefore degrading timing.
Decreasing the max fanout during synthesis worsened the situation by causing register replication and further increasing routing congestion.
Now, the instruction_operation gets translated into control signals that are passed to the execute stage.
The top-level RS5.sv was also reviewed and reorganized, moving the memory-access stage to a separate module.

To merge, we still need:

* [x] A thorough review of the new code
* [x] Apply the same rework to the vector extension
* [x] Apply the same rework to CSRBank, removing instruction_operation_o for good
* [x]  Pass RISCOF baseline
* [x]  Pass RISCOF extensions
* [x] Pass riscv-tests (which include CSR, privilege, and LR/SC not present in RISCOF)
* [x] Test with Memphis (for privilege stress)
* [ ] Test with Zve32x
* [ ] Test with Wimed (synthesis)

Comparing against the master branch (with all ISEs enabled, excluding non-standard ones) with post-route phys_opt_design (AggressiveExplore), we have:
| branch | setup slack | setup slack (opt) | LUT | FF |
| ---- | ---- | --- | --- | --- |
| master    | -0.055 | +0.058 | 4046 | 1441 |
| this one | +0.084 | --- | 4142 | 1496 |

Notes: 
* The LUT/FF usage includes only the RS5 module.
* This branch drops the requirement for post-route phys_opt_design, and closes timing rapidly
* I've made another Vivado run without Zknh but with Xkyber, and it also passes timing by +0.052 without needing post-route phys_opt_design.